### PR TITLE
PLUGIN-1101: Remove new_call table from Product Catalog

### DIFF
--- a/src/main/java/io/cdap/plugin/servicenow/source/util/SourceApplication.java
+++ b/src/main/java/io/cdap/plugin/servicenow/source/util/SourceApplication.java
@@ -37,7 +37,7 @@ public enum SourceApplication {
   /**
    * Data from tables related to Product Catalog will be fetched.
    */
-  PRODUCT_CATALOG("Product Catalog", Arrays.asList("new_call", "pc_hardware_cat_item", "pc_product_cat_item",
+  PRODUCT_CATALOG("Product Catalog", Arrays.asList("pc_hardware_cat_item", "pc_product_cat_item",
     "pc_software_cat_item", "pc_vendor_cat_item")),
 
   /**


### PR DESCRIPTION
[PLUGIN-1101](https://cdap.atlassian.net/browse/PLUGIN-1101): This table has been deprecated and is no longer part of the plugin.
Table new_call is part of the deprecated plugin Service Desk Call plugin (com.snc.service_desk_call) is deprecated in the Quebec release. 