### PR TITLE
PLUGIN-1142: Display output schema only for Table Mode in ServiceNow Batch Source Plugin

### DIFF
--- a/src/main/java/io/cdap/plugin/servicenow/source/ServiceNowSource.java
+++ b/src/main/java/io/cdap/plugin/servicenow/source/ServiceNowSource.java
@@ -75,9 +75,11 @@ public class ServiceNowSource extends BatchSource<NullWritable, StructuredRecord
     // Since we have validated all the properties, throw an exception if there are any errors in the collector.
     // This is to avoid adding same validation errors again in getSchema method call
     collector.getOrThrowException();
-    if (conf.shouldGetSchema()) {
+    if (conf.shouldGetSchema() && conf.getQueryMode() == SourceQueryMode.TABLE) {
       List<ServiceNowTableInfo> tableInfo = ServiceNowInputFormat.fetchTableInfo(conf.getQueryMode(collector), conf);
-      stageConfigurer.setOutputSchema(tableInfo.get(0).getSchema());
+      stageConfigurer.setOutputSchema(tableInfo.stream().findFirst().get().getSchema());
+    } else if (conf.getQueryMode() == SourceQueryMode.REPORTING) {
+      stageConfigurer.setOutputSchema(null);
     }
   }
 


### PR DESCRIPTION
[PLUGIN-1142](https://cdap.atlassian.net/browse/PLUGIN-1142)

~**ServiceNow Multi-Source:** Display output schema only when data is requested for one table. No schema would be displayed if data is requested for more than one table~

**ServiceNow Batch Source:** Display output schema only for Table mode. No schema would be displayed for Reporting Mode