### PR TITLE
PLUGIN-1645 : Fix endate validation issue and PLUGIN-1651: Fail pipeline if data receovery failed error occurs

### DIFF
--- a/src/main/java/io/cdap/plugin/servicenow/apiclient/ServiceNowTableAPIClientImpl.java
+++ b/src/main/java/io/cdap/plugin/servicenow/apiclient/ServiceNowTableAPIClientImpl.java
@@ -346,7 +346,7 @@ public class ServiceNowTableAPIClientImpl extends RestAPIClient {
    */
   public List<Map<String, Object>> fetchTableRecordsRetryableMode(String tableName, SourceValueType valueType,
                                                                   String startDate, String endDate, int offset,
-                                                                  int limit) {
+                                                                  int limit) throws IOException {
     final List<Map<String, Object>> results = new ArrayList<>();
     Callable<Boolean> fetchRecords = () -> {
       results.addAll(fetchTableRecords(tableName, valueType, startDate, endDate, offset, limit));
@@ -362,8 +362,7 @@ public class ServiceNowTableAPIClientImpl extends RestAPIClient {
     try {
       retryer.call(fetchRecords);
     } catch (RetryException | ExecutionException e) {
-      LOG.error("Data Recovery failed for batch {} to {}.", offset,
-                (offset + limit));
+      throw new IOException(String.format("Data Recovery failed for batch %s to %s.", offset, (offset + limit)), e);
     }
 
     return results;

--- a/src/main/java/io/cdap/plugin/servicenow/source/ServiceNowMultiRecordReader.java
+++ b/src/main/java/io/cdap/plugin/servicenow/source/ServiceNowMultiRecordReader.java
@@ -80,7 +80,7 @@ public class ServiceNowMultiRecordReader extends ServiceNowBaseRecordReader {
   }
 
   @VisibleForTesting
-  void fetchData() {
+  void fetchData() throws IOException {
     tableName = split.getTableName();
     tableNameField = multiSourcePluginConf.getTableNameField();
 

--- a/src/main/java/io/cdap/plugin/servicenow/source/ServiceNowRecordReader.java
+++ b/src/main/java/io/cdap/plugin/servicenow/source/ServiceNowRecordReader.java
@@ -84,7 +84,7 @@ public class ServiceNowRecordReader extends ServiceNowBaseRecordReader {
     return recordBuilder.build();
   }
 
-  private void fetchData() {
+  private void fetchData() throws IOException {
     tableName = split.getTableName();
     tableNameField = pluginConf.getTableNameField();
 


### PR DESCRIPTION
GA release fixes contain the following:
-  [PLUGIN-1645](https://cdap.atlassian.net/browse/PLUGIN-1645) : Fix endate validation issue
- [PLUGIN-1651](https://cdap.atlassian.net/browse/PLUGIN-1651) : Fail pipeline if data recovery failed error occurs

For code fix one pager please refer: [ServiceNow Bug Fixes.docx](https://github.com/data-integrations/servicenow-plugins/files/12240311/ServiceNow.Bug.Fixes.docx)


[PLUGIN-1645]: https://cdap.atlassian.net/browse/PLUGIN-1645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PLUGIN-1651]: https://cdap.atlassian.net/browse/PLUGIN-1651?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ