### PR TITLE
Fix error thrown by connector when 429 response code is received

### DIFF
--- a/src/main/java/io/cdap/plugin/servicenow/apiclient/RetryableException.java
+++ b/src/main/java/io/cdap/plugin/servicenow/apiclient/RetryableException.java
@@ -26,5 +26,9 @@ public class RetryableException extends RuntimeException {
   public RetryableException() {
          super();
   }
+
+    public RetryableException(String message) {
+        super(message);
+    }
   
 }

--- a/src/main/java/io/cdap/plugin/servicenow/apiclient/ServiceNowTableAPIClientImpl.java
+++ b/src/main/java/io/cdap/plugin/servicenow/apiclient/ServiceNowTableAPIClientImpl.java
@@ -132,9 +132,15 @@ public class ServiceNowTableAPIClientImpl extends RestAPIClient {
       apiResponse = executeGet(requestBuilder.build());
       if (!apiResponse.isSuccess()) {
         if (apiResponse.isRetryable()) {
-          throw new RetryableException();
+          throw new RetryableException(
+                  String.format(
+                          "Error in fetchTableRecords, http response code = %d, message = %s",
+                          apiResponse.getHttpStatus(), apiResponse.getResponseBody()));
         }
-        return Collections.emptyList();
+        throw new RuntimeException(
+                String.format(
+                        "Error in fetchTableRecords, http response code = %d, message = %s",
+                        apiResponse.getHttpStatus(), apiResponse.getResponseBody()));
       }
 
       return parseResponseToResultListOfMap(apiResponse.getResponseBody());

--- a/src/main/java/io/cdap/plugin/servicenow/restapi/RestAPIResponse.java
+++ b/src/main/java/io/cdap/plugin/servicenow/restapi/RestAPIResponse.java
@@ -18,6 +18,7 @@ package io.cdap.plugin.servicenow.restapi;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonSyntaxException;
 import io.cdap.plugin.servicenow.util.ServiceNowConstants;
 import org.apache.http.Header;
 import org.apache.http.HttpResponse;
@@ -48,6 +49,7 @@ public class RestAPIResponse {
     "    },\n" +
     "    \"status\": \"failure\"\n" +
     "}";
+  private static final int HTTP_STATUS_TOO_MANY_REQUESTS = 429;
   private int httpStatus;
   private Map<String, String> headers;
   private String responseBody;
@@ -116,12 +118,31 @@ public class RestAPIResponse {
 
   private void checkRetryable() {
     Gson gson = new Gson();
-    JsonObject jo = gson.fromJson(this.responseBody, JsonObject.class);
-    if (jo.get(ServiceNowConstants.STATUS) != null &&
-      jo.get(ServiceNowConstants.STATUS).getAsString().equals(ServiceNowConstants.FAILURE) &&
-      jo.getAsJsonObject(ServiceNowConstants.ERROR).get(ServiceNowConstants.MESSAGE).getAsString()
-        .contains(ServiceNowConstants.MAXIMUM_EXECUTION_TIME_EXCEEDED)) {
-      isRetryable = true;
+    try {
+      JsonObject jo = gson.fromJson(this.responseBody, JsonObject.class);
+      if (jo.get(ServiceNowConstants.STATUS) != null
+              && jo.get(ServiceNowConstants.STATUS).getAsString().equals(ServiceNowConstants.FAILURE)
+              && jo.getAsJsonObject(ServiceNowConstants.ERROR)
+              .get(ServiceNowConstants.MESSAGE)
+              .getAsString()
+              .contains(ServiceNowConstants.MAXIMUM_EXECUTION_TIME_EXCEEDED)) {
+        isRetryable = true;
+      }
+    } catch (JsonSyntaxException e) {
+      // Response Body is not a json object - check status code for error
+      // Response body necessarily need not be json always (when 429 error is thrown -
+      // responseBody is HTML)
+      if (httpStatus == HTTP_STATUS_TOO_MANY_REQUESTS) {
+        isRetryable = true;
+        this.responseBody =
+                String.format(
+                        JSON_ERROR_RESPONSE_TEMPLATE,
+                        "Too many requests to ServiceNow API - decrease concurrent requests");
+      }
+    } catch (Throwable t) {
+      // Any other exception
+      isRetryable = false;
+      this.responseBody = String.format(JSON_ERROR_RESPONSE_TEMPLATE, t.getMessage());
     }
   }
 


### PR DESCRIPTION
1. When ServiceNow API throws 429 error, response body is HTML (and not json as expected) which causes `JsonSyntaxException` while serializing to Json. This PR addresses this fix and throws a meaningful error.
2. When ServiceNow API errors out when fetching table records, `ServiceNowTableAPIClientImpl.fetchTableRecords` returns  empty list which can cause data loss. Now this will throw an error instead of empty list.