### PR TITLE
"[PLUGIN-1901] Time datatype support for actual value type"

### DIFF
--- a/src/main/java/io/cdap/plugin/servicenow/apiclient/ServiceNowTableAPIClientImpl.java
+++ b/src/main/java/io/cdap/plugin/servicenow/apiclient/ServiceNowTableAPIClientImpl.java
@@ -68,6 +68,8 @@ public class ServiceNowTableAPIClientImpl extends RestAPIClient {
   private static final String FIELD_CREATED_ON = "sys_created_on";
   private static final String FIELD_UPDATED_ON = "sys_updated_on";
   private static final String OAUTH_URL_TEMPLATE = "%s/oauth_token.do";
+  private static final String GLIDE_TIME_DATATYPE = "glide_time";
+  private static final String GLIDE_DATE_TIME_DATATYPE = "glide_date_time";
   private static final Gson GSON = new Gson();
   private final ServiceNowConnectorConfig conf;
   public static JsonArray serviceNowJsonResultArray;
@@ -309,6 +311,9 @@ public class ServiceNowTableAPIClientImpl extends RestAPIClient {
       if (valueType.equals(SourceValueType.SHOW_DISPLAY_VALUE) &&
         !Objects.equals(field.getType(), field.getInternalType())) {
         columns.add(new ServiceNowColumn(field.getName(), field.getType()));
+      } else if (valueType.equals(SourceValueType.SHOW_ACTUAL_VALUE) &&
+        GLIDE_TIME_DATATYPE.equalsIgnoreCase(field.getInternalType())) {
+        columns.add(new ServiceNowColumn(field.getName(), GLIDE_DATE_TIME_DATATYPE));
       } else {
         columns.add(new ServiceNowColumn(field.getName(), field.getInternalType()));
       }

--- a/src/test/java/io/cdap/plugin/servicenow/apiclient/ServiceNowTableAPIClientImplTest.java
+++ b/src/test/java/io/cdap/plugin/servicenow/apiclient/ServiceNowTableAPIClientImplTest.java
@@ -118,6 +118,42 @@ public class ServiceNowTableAPIClientImplTest {
   }
 
   @Test
+  public void testFetchTableSchema_GlideTimeFieldWithActualValueType() throws Exception {
+    ServiceNowConnectorConfig mockConfig = Mockito.mock(ServiceNowConnectorConfig.class);
+    ServiceNowTableAPIClientImpl impl = new ServiceNowTableAPIClientImpl(mockConfig);
+    ServiceNowTableAPIClientImpl implSpy = Mockito.spy(impl);
+
+    String jsonResponse = "{\n" +
+      "  \"result\": {\n" +
+      "    \"columns\": {\n" +
+      "      \"u_start_time\": {\n" +
+      "        \"label\": \"Start Time\",\n" +
+      "        \"name\": \"u_start_time\",\n" +
+      "        \"type\": \"string\",\n" +
+      "        \"internal_type\": \"glide_time\"\n" +
+      "      }\n" +
+      "    }\n" +
+      "  }\n" +
+      "}";
+
+    RestAPIResponse mockResponse = new RestAPIResponse(Collections.emptyMap(), jsonResponse, null);
+    Mockito.doReturn(mockResponse).when(implSpy).executeGetWithRetries(Mockito.any());
+
+    Schema schema = implSpy.fetchTableSchema("u_custom_table", "dummy-access-token",
+      SourceValueType.SHOW_ACTUAL_VALUE);
+
+    Assert.assertNotNull(schema);
+    Assert.assertEquals("record", schema.getDisplayName());
+    Assert.assertEquals(1, schema.getFields().size());
+
+    Schema.Field field = schema.getField("u_start_time");
+    Assert.assertNotNull(field);
+
+    Schema fieldSchema = field.getSchema().getUnionSchemas().get(0);
+    Assert.assertEquals(Schema.LogicalType.DATETIME, fieldSchema.getLogicalType());
+  }
+
+  @Test
   public void testFetchTableSchema_DisplayValueType() throws Exception {
     ServiceNowConnectorConfig mockConfig = Mockito.mock(ServiceNowConnectorConfig.class);
     ServiceNowTableAPIClientImpl impl = new ServiceNowTableAPIClientImpl(mockConfig);


### PR DESCRIPTION
**Issue:** for fields of type `glide_time` in ServiceNow, when the value is retrieved using the `actual` value type, it is returned in a `glide_datetime` format. This causes a parsing failure, as the expected format for `glide_time` is not maintained. However, when using the `display` value type, the value is correctly returned as `glide_time`.

**Root Cause:** ServiceNow automatically prefixes a default date to `glide_time` values when accessed via the `actual` value type, converting it to `datetime` format.

**Fix:** implemented explicit handling to map `glide_time` fields to `datetime` when using the `actual` value type.

**JIRA Ticket:** https://cdap.atlassian.net/browse/PLUGIN-1901