### PR TITLE
[PLUGIN-1904] Fix: Vulnerability issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,7 @@
     <junit.version>4.12</junit.version>
     <slf4j.version>1.7.5</slf4j.version>
     <powermock.version>2.0.2</powermock.version>
+    <json.version>20231013</json.version>
     <testSourceLocation>${project.basedir}/src/test/java/</testSourceLocation>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -275,6 +276,11 @@
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
       <version>1.2.8</version>
+    </dependency>
+    <dependency>
+      <groupId>org.json</groupId>
+      <artifactId>json</artifactId>
+      <version>${json.version}</version>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -240,6 +240,12 @@
     <dependency>
       <groupId>org.apache.oltu.oauth2</groupId>
       <artifactId>org.apache.oltu.oauth2.client</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.json</groupId>
+          <artifactId>json</artifactId>
+        </exclusion>
+      </exclusions>
       <version>1.0.2</version>
     </dependency>
     <dependency>


### PR DESCRIPTION
Issue:
Resolved high-severity Denial of Service (DoS) vulnerabilities in the org.json:json library and related components. JSON-Java versions up to and including 20230618 included a parser flaw that permitted modestly sized inputs to consume excessive memory, while a stack overflow in the XML.toJSONObject component of hutool-json v5.8.10 and org.json:json versions prior to 20230227 allowed attackers to trigger DoS through crafted JSON or XML payloads. These issues are associated with CVE-2022-45688 and CVE-2023-5072—both classified as high severity.

Root Cause:
Insufficient validation and lack of resource management in the parser exposed the system to stack overflows and memory exhaustion when processing maliciously structured input data.

Fix:
Upgraded org.json:json to secure version 20231013 to resolve both CVE-2022-45688 and CVE-2023-5072, ensuring improved input validation and robust resource limits to prevent DoS exploitation.

JIRA Ticket : https://cdap.atlassian.net/browse/PLUGIN-1904