### PR TITLE
Fix: Vulnerability for logback-classic

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -268,7 +268,7 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.2.8</version>
+      <version>1.5.16</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Issue:
Resolved a high-severity Denial of Service (DoS) vulnerability (https://github.com/advisories/GHSA-vmq6-5m68-f53m) in the logback receiver component (ch.qos.logback:logback-classic). This vulnerability allowed attackers to exploit a serialization flaw by sending malicious data to the receiver component, potentially causing system unavailability. The issue is present in environments where the logback receiver component is deployed, specifically affecting logback-classic version 1.2.8.

Root Cause:
The logback receiver component failed to adequately validate serialized input data. If the receiver was enabled, attackers could send specially crafted serialized payloads that triggered resource exhaustion, leading to Denial of Service.

Fix : Upgraded ch.qos.logback:logback-classic to the 1.5.16.

JIRA Ticket : https://cdap.atlassian.net/browse/PLUGIN-1907