### PR TITLE
Fix: Vulnerability for httpClient

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
     <cdap.version>6.8.0</cdap.version>
     <cdap.plugin.version>2.10.0</cdap.plugin.version>
     <hadoop.version>2.10.2</hadoop.version>
-    <httpclient.version>4.3.4</httpclient.version>
+    <httpclient.version>4.5.13</httpclient.version>
     <jackson.core.version>2.8.11.1</jackson.core.version>
     <junit.version>4.12</junit.version>
     <slf4j.version>1.7.5</slf4j.version>


### PR DESCRIPTION
Issue :
This PR fixes multiple medium-severity security vulnerabilities in Apache HttpClient 4.3.4: CVE-2020-13956 (incorrect host resolution due to malformed URIs), CVE-2014-3577 (improper SSL hostname verification allowing MITM attacks), and CVE-2015-5262 (socket timeout not applied during SSL handshake, causing potential DoS).

Root Cause :
The issues stem from using an outdated HttpClient version (4.3.4). This version does not correctly parse malformed URIs, fails to validate SSL certificate hostnames properly, and ignores socket timeout configurations during SSL handshakes.

Fix :
Upgraded  httpclient to a secure version 4.5.13.

Jira :
https://cdap.atlassian.net/browse/PLUGIN-1914

