### PR TITLE
[PLUGIN-1915]: Fix CVEs in com.google.guava:31.1-jre 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,12 @@
       <groupId>io.cdap.plugin</groupId>
       <artifactId>hydrator-common</artifactId>
       <version>${cdap.plugin.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>io.cdap.cdap</groupId>
@@ -506,7 +512,7 @@
           <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>31.0.1-jre</version>
+            <version>33.4.0-jre</version>
             <scope>compile</scope>
           </dependency>
         </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -259,7 +259,7 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.3.15</version>
+      <version>1.2.8</version>
     </dependency>
     <dependency>
       <groupId>org.json</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
     <cdap.version>6.8.0</cdap.version>
     <cdap.plugin.version>2.10.0</cdap.plugin.version>
     <hadoop.version>2.10.2</hadoop.version>
-    <httpclient.version>4.3.4</httpclient.version>
+    <httpclient.version>4.5.13</httpclient.version>
     <jackson.core.version>2.8.11.1</jackson.core.version>
     <junit.version>4.12</junit.version>
     <slf4j.version>1.7.5</slf4j.version>
@@ -259,7 +259,7 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.2.8</version>
+      <version>1.3.15</version>
     </dependency>
     <dependency>
       <groupId>org.json</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -513,7 +513,7 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>32.1.3-jre</version>
-            <scope>compile</scope>
+            <scope>test</scope>
           </dependency>
         </dependencies>
       </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,12 @@
 
   <dependencies>
     <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>32.1.3-jre</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
       <groupId>io.cdap.cdap</groupId>
       <artifactId>cdap-etl-api</artifactId>
       <version>${cdap.version}</version>
@@ -243,6 +249,12 @@
       <groupId>com.github.rholder</groupId>
       <artifactId>guava-retrying</artifactId>
       <version>2.0.0</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.powermock</groupId>
@@ -513,7 +525,7 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>32.1.3-jre</version>
-            <scope>compile</scope>
+            <scope>test</scope>
           </dependency>
         </dependencies>
       </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,12 @@
   </dependencyManagement>
   <dependencies>
     <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>32.1.3-jre</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
       <groupId>io.cdap.cdap</groupId>
       <artifactId>cdap-etl-api</artifactId>
       <version>${cdap.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -512,7 +512,7 @@
           <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>33.4.0-jre</version>
+            <version>32.1.3-jre</version>
             <scope>compile</scope>
           </dependency>
         </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -81,13 +81,17 @@
     </repository>
   </repositories>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava</artifactId>
+        <version>32.1.3-jre</version>
+        <scope>compile</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
   <dependencies>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>32.1.3-jre</version>
-      <scope>compile</scope>
-    </dependency>
     <dependency>
       <groupId>io.cdap.cdap</groupId>
       <artifactId>cdap-etl-api</artifactId>
@@ -525,7 +529,7 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>32.1.3-jre</version>
-            <scope>test</scope>
+            <scope>compile</scope>
           </dependency>
         </dependencies>
       </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -513,7 +513,7 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>32.1.3-jre</version>
-            <scope>test</scope>
+            <scope>compile</scope>
           </dependency>
         </dependencies>
       </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
     <cdap.version>6.8.0</cdap.version>
     <cdap.plugin.version>2.10.0</cdap.plugin.version>
     <hadoop.version>2.10.2</hadoop.version>
-    <httpclient.version>4.5.13</httpclient.version>
+    <httpclient.version>4.3.4</httpclient.version>
     <jackson.core.version>2.8.11.1</jackson.core.version>
     <junit.version>4.12</junit.version>
     <slf4j.version>1.7.5</slf4j.version>


### PR DESCRIPTION
**Issue:**
**Guava (com.google.guava:31.1-jre):** Use of Java's default temporary directory for file creation in FileBackedOutputStream in Google Guava versions 1.0 to 31.1 on Unix systems and Android Ice Cream Sandwich allows other users and apps on the machine with access to the default Java temporary directory to be able to access the files created by the class. Even though the security vulnerability is fixed in version 32.0.0, maintainers recommend using version 32.0.1 as version 32.0.0 breaks some functionality under Windows.

**Root Cause:**
**Guava :** FileBackedOutputStream uses temporary files to store data once a certain memory threshold is exceeded. This can result in failure to sufficiently restrict access to the temp file, making it susceptible to race conditions or file hijacking. It can further allow unauthorized access or modification of the temporary file by other processes/users on the system.

**Fix:**
Add the guava dependency to the exclusions and upgrade to a higher version such as 33.4.0-jre to get rid of the CVE.

**JIRA** : [PLUGIN-1915](https://cdap.atlassian.net/browse/PLUGIN-1915)

[PLUGIN-1915]: https://cdap.atlassian.net/browse/PLUGIN-1915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ