### PR TITLE
Remove -SNAPSHOT for release 1.2.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
   <groupId>io.cdap.plugin</groupId>
   <artifactId>servicenow-plugins</artifactId>
-  <version>1.2.6-SNAPSHOT</version>
+  <version>1.2.6</version>
   <name>ServiceNow Plugins</name>
   <packaging>jar</packaging>
   <description>Plugins for ServiceNow</description>


### PR DESCRIPTION
Update version from `1.2.6-SNAPSHOT` to `1.2.6` in pom.xml for servicenow-plugins