### PR TITLE
PLUGIN-1927: Map fields ending with `_stc` to string type

### DIFF
--- a/src/main/java/io/cdap/plugin/servicenow/apiclient/ServiceNowTableAPIClientImpl.java
+++ b/src/main/java/io/cdap/plugin/servicenow/apiclient/ServiceNowTableAPIClientImpl.java
@@ -65,6 +65,8 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 
+import static io.cdap.plugin.servicenow.util.ServiceNowConstants.STC_FIELD_SUFFIX;
+
 /**
  * Implementation class for ServiceNow Table API.
  */
@@ -393,9 +395,14 @@ public class ServiceNowTableAPIClientImpl extends RestAPIClient {
     }
 
     for (MetadataAPISchemaField field : metadataAPISchemaResponse.getResult().getColumns().values()) {
-      if (valueType.equals(SourceValueType.SHOW_DISPLAY_VALUE) &&
-        !Objects.equals(field.getType(), field.getInternalType())) {
-        columns.add(new ServiceNowColumn(field.getName(), field.getType()));
+      if (valueType.equals(SourceValueType.SHOW_DISPLAY_VALUE)) {
+        if (!Objects.equals(field.getType(), field.getInternalType())) {
+          columns.add(new ServiceNowColumn(field.getName(), field.getType()));
+        } else if (field.getName().endsWith(STC_FIELD_SUFFIX) && field.getType().equals("integer")) {
+          columns.add(new ServiceNowColumn(field.getName(), Schema.Type.STRING.name()));
+        } else {
+          columns.add(new ServiceNowColumn(field.getName(), field.getInternalType()));
+        }
       } else if (valueType.equals(SourceValueType.SHOW_ACTUAL_VALUE) &&
         GLIDE_TIME_DATATYPE.equalsIgnoreCase(field.getInternalType())) {
         columns.add(new ServiceNowColumn(field.getName(), GLIDE_DATE_TIME_DATATYPE));

--- a/src/main/java/io/cdap/plugin/servicenow/util/ServiceNowConstants.java
+++ b/src/main/java/io/cdap/plugin/servicenow/util/ServiceNowConstants.java
@@ -281,4 +281,9 @@ public interface ServiceNowConstants {
    * Default Precision supported by ServiceNow Rest API
    */
   int DEFAULT_PRECISION = 20;
+
+  /**
+   * Suffix for ServiceNow fields that store elapsed time in seconds (e.g., calendar_stc, business_stc).
+   */
+  String STC_FIELD_SUFFIX = "_stc";
 }

--- a/src/test/java/io/cdap/plugin/servicenow/apiclient/ServiceNowTableAPIClientImplTest.java
+++ b/src/test/java/io/cdap/plugin/servicenow/apiclient/ServiceNowTableAPIClientImplTest.java
@@ -187,4 +187,41 @@ public class ServiceNowTableAPIClientImplTest {
     Assert.assertEquals(Schema.Type.STRING,
       schema.getField("user_name").getSchema().getUnionSchemas().get(0).getType());
   }
+
+  @Test
+  public void testFetchTableSchema_StcFieldsWithDisplayValueType_ParseAsString() throws Exception {
+
+    ServiceNowConnectorConfig mockConfig = Mockito.mock(ServiceNowConnectorConfig.class);
+    ServiceNowTableAPIClientImpl impl = new ServiceNowTableAPIClientImpl(mockConfig, true);
+    ServiceNowTableAPIClientImpl implSpy = Mockito.spy(impl);
+    String jsonResponse = "{\n" +
+      "  \"result\": {\n" +
+      "    \"columns\": {\n" +
+      "      \"calendar_stc\": {\n" +
+      "        \"label\": \"Resolve time\",\n" +
+      "        \"type\": \"integer\",\n" +
+      "        \"name\": \"calendar_stc\",\n" +
+      "        \"internal_type\": \"integer\"\n" +
+      "      },\n" +
+      "      \"business_stc\": {\n" +
+      "        \"label\": \"Business resolve time\",\n" +
+      "        \"type\": \"integer\",\n" +
+      "        \"name\": \"business_stc\",\n" +
+      "        \"internal_type\": \"integer\"\n" +
+      "      }\n" +
+      "    }\n" +
+      "  }\n" +
+      "}";
+    RestAPIResponse mockResponse = new RestAPIResponse(Collections.emptyMap(), jsonResponse, null);
+    Mockito.doReturn(mockResponse).when(implSpy).executeGetWithRetries(Mockito.any());
+    Schema schema = implSpy.fetchTableSchema("incident", "dummy-access-token",
+                                             SourceValueType.SHOW_DISPLAY_VALUE, SchemaType.METADATA_API_BASED);
+    Assert.assertNotNull(schema);
+    Assert.assertEquals("record", schema.getDisplayName());
+    Assert.assertEquals(2, schema.getFields().size());
+    Assert.assertEquals(Schema.Type.STRING,
+                        schema.getField("business_stc").getSchema().getUnionSchemas().get(0).getType());
+    Assert.assertEquals(Schema.Type.STRING,
+                        schema.getField("calendar_stc").getSchema().getUnionSchemas().get(0).getType());
+  }
 }


### PR DESCRIPTION
[PLUGIN-1927](https://cdap.atlassian.net/browse/PLUGIN-1927)

**Issue:** The display values for `calendar_stc` and `business_stc` fields from the ServiceNow Incident table are getting truncated before getting populated in BigQuery. 

**Fix:** For display value, update the mapping to `string` type for all fields with `integer` type and their name ending with `_stc` and having same type as the internal type as seen through the new ServiceNow Metadata API

[PLUGIN-1927]: https://cdap.atlassian.net/browse/PLUGIN-1927?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ