### PR TITLE
Remove -SNAPSHOT version from 1.2.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
   <groupId>io.cdap.plugin</groupId>
   <artifactId>servicenow-plugins</artifactId>
-  <version>1.2.8-SNAPSHOT</version>
+  <version>1.2.8</version>
   <name>ServiceNow Plugins</name>
   <packaging>jar</packaging>
   <description>Plugins for ServiceNow</description>


### PR DESCRIPTION
Update version from `1.2.8-SNAPSHOT` to `1.2.8` in pom.xml for servicenow-plugins