### PR TITLE
PLUGIN-1936: Read data in a streaming manner

### DIFF
--- a/src/e2e-test/java/io/cdap/plugin/servicenowsink/actions/ServiceNowSinkPropertiesPageActions.java
+++ b/src/e2e-test/java/io/cdap/plugin/servicenowsink/actions/ServiceNowSinkPropertiesPageActions.java
@@ -48,11 +48,11 @@ import java.util.Map;
 
 public class ServiceNowSinkPropertiesPageActions {
   public static ServiceNowSourceConfig config;
-  private static Map<String, String> responseFromServiceNowTable;
+  private static JsonObject responseFromServiceNowTable;
   private static Gson gson = new Gson();
 
   public static void getRecordFromServiceNowTable(String query, String tableName)
-      throws ServiceNowAPIException {
+      throws ServiceNowAPIException, IOException {
     config = new ServiceNowSourceConfig(
         "", "", "", "", "",
         System.getenv("SERVICE_NOW_CLIENT_ID"),
@@ -71,10 +71,8 @@ public class ServiceNowSinkPropertiesPageActions {
     String bqTable = TestSetupHooks.bqTargetTable;
     getRecordFromServiceNowTable(query, tableName);
 
-    JsonObject jsonObject = new JsonObject();
-    responseFromServiceNowTable.forEach(jsonObject::addProperty);
     List<JsonObject> serviceNowResponse = new ArrayList<>();
-    serviceNowResponse.add(jsonObject);
+    serviceNowResponse.add(responseFromServiceNowTable);
 
     List<JsonObject> bigQueryResponse = new ArrayList<>();
     List<Object> bigQueryRows = new ArrayList<>();

--- a/src/main/java/io/cdap/plugin/servicenow/ServiceNowBaseConfig.java
+++ b/src/main/java/io/cdap/plugin/servicenow/ServiceNowBaseConfig.java
@@ -17,6 +17,7 @@
 package io.cdap.plugin.servicenow;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.gson.stream.JsonReader;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Macro;
 import io.cdap.cdap.api.annotation.Name;
@@ -31,7 +32,11 @@ import io.cdap.plugin.servicenow.source.ServiceNowSourceConfig;
 import io.cdap.plugin.servicenow.util.SchemaType;
 import io.cdap.plugin.servicenow.util.ServiceNowConstants;
 import io.cdap.plugin.servicenow.util.SourceValueType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
+import java.io.InputStreamReader;
 import javax.annotation.Nullable;
 
 /**
@@ -39,6 +44,7 @@ import javax.annotation.Nullable;
  */
 public class ServiceNowBaseConfig extends PluginConfig {
 
+  private static final Logger log = LoggerFactory.getLogger(ServiceNowBaseConfig.class);
   @Name(ConfigUtil.NAME_USE_CONNECTION)
   @Nullable
   @Description("Whether to use an existing connection.")
@@ -140,7 +146,7 @@ public class ServiceNowBaseConfig extends PluginConfig {
       requestBuilder.setResponseHeaders(ServiceNowConstants.HEADER_NAME_TOTAL_COUNT);
 
       apiResponse = serviceNowTableAPIClient.executeGetWithRetries(requestBuilder.build());
-      if (serviceNowTableAPIClient.parseResponseToResultListOfMap(apiResponse.getResponseBody()).isEmpty()) {
+      if (isResultEmpty(apiResponse)) {
         // Removed config property as in case of MultiSource, only first table error was populating.
         collector.addFailure("Table: " + tableName + " is empty.", "");
       }
@@ -150,6 +156,33 @@ public class ServiceNowBaseConfig extends PluginConfig {
                            "Ensure specified table exists in the datasource. ")
         .withConfigProperty(ServiceNowConstants.PROPERTY_TABLE_NAME);
     }
+  }
+
+  /**
+   * Checks if the "result" array in the ServiceNow REST API response is empty.
+   * <p>
+   * Determines if the "result" array in a ServiceNow REST API response is empty by specifically looking for a top-level
+   * key named "result". Once found, it opens the associated array and checks for the presence of a first element.
+   * </p>
+   * 
+   * @param restAPIResponse The response object containing the JSON input stream
+   * @return true, if the "result" array exists and is empty, or if the "result" key is never found;
+   * false, if the array contains at least one element.
+   * @throws IOException If there is an error reading the input stream or parsing the JSON.
+   */
+  public boolean isResultEmpty(RestAPIResponse restAPIResponse) throws IOException {
+    JsonReader reader = new JsonReader(new InputStreamReader(restAPIResponse.getResponseStream()));
+    reader.beginObject();
+    while (reader.hasNext()) {
+      String name = reader.nextName();
+      if (ServiceNowConstants.RESULT.equals(name)) {
+        reader.beginArray();
+        return !reader.hasNext();
+      } else {
+        reader.skipValue();
+      }
+    }
+    return true;
   }
 
 }

--- a/src/main/java/io/cdap/plugin/servicenow/apiclient/ServiceNowAPIException.java
+++ b/src/main/java/io/cdap/plugin/servicenow/apiclient/ServiceNowAPIException.java
@@ -8,6 +8,7 @@ import org.apache.http.conn.ConnectTimeoutException;
 import org.apache.oltu.oauth2.common.exception.OAuthSystemException;
 
 import java.net.SocketException;
+import java.net.SocketTimeoutException;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
@@ -69,6 +70,7 @@ public class ServiceNowAPIException extends Exception {
     return t instanceof OAuthSystemException
         || t instanceof ConnectTimeoutException
         || t instanceof SocketException
+        || t instanceof SocketTimeoutException
         || (this.getMessage() != null
         && this.getMessage().contains(ServiceNowConstants.MAXIMUM_EXECUTION_TIME_EXCEEDED))
         || RETRYABLE_CODES.contains(getStatusCode());

--- a/src/main/java/io/cdap/plugin/servicenow/apiclient/ServiceNowTableAPIClientImpl.java
+++ b/src/main/java/io/cdap/plugin/servicenow/apiclient/ServiceNowTableAPIClientImpl.java
@@ -27,7 +27,7 @@ import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.reflect.TypeToken;
-import com.sun.org.apache.xpath.internal.operations.Bool;
+import com.google.gson.stream.JsonReader;
 import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.etl.api.FailureCollector;
 import io.cdap.plugin.servicenow.connector.ServiceNowConnectorConfig;
@@ -56,7 +56,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -86,6 +89,7 @@ public class ServiceNowTableAPIClientImpl extends RestAPIClient {
   public static JsonArray serviceNowJsonResultArray;
 
   public ServiceNowTableAPIClientImpl(ServiceNowConnectorConfig conf, Boolean useConnection) {
+    super();
     this.conf = conf;
     this.schemaType = getSchemaTypeBasedOnUseConnection(useConnection);
   }
@@ -135,7 +139,7 @@ public class ServiceNowTableAPIClientImpl extends RestAPIClient {
    * @return A list of maps, where each map represents a record from the table.
    * @throws ServiceNowAPIException If an error occurs while fetching the records.
    */
-  public List<Map<String, String>> fetchTableRecords(
+  public RestAPIResponse fetchTableRecords(
     String tableName,
     SourceValueType valueType,
     String filterQuery,
@@ -148,6 +152,8 @@ public class ServiceNowTableAPIClientImpl extends RestAPIClient {
       .setDisplayValue(valueType)
       .setLimit(limit);
 
+    requestBuilder.setResponseHeaders(ServiceNowConstants.HEADER_NAME_TOTAL_COUNT);
+
     if (offset > 0) {
       requestBuilder.setOffset(offset);
     }
@@ -159,7 +165,7 @@ public class ServiceNowTableAPIClientImpl extends RestAPIClient {
     String accessToken = getAccessToken();
     requestBuilder.setAuthHeader(accessToken);
     RestAPIResponse apiResponse = executeGetWithRetries(requestBuilder.build());
-    return parseResponseToResultListOfMap(apiResponse.getResponseBody());
+    return apiResponse;
   }
 
   private int getRecordCountFromHeader(RestAPIResponse apiResponse) {
@@ -209,30 +215,24 @@ public class ServiceNowTableAPIClientImpl extends RestAPIClient {
    * @param limit     The number of records to be fetched
    * @return The list of Map; each Map representing a table row
    */
-  public List<Map<String, String>> fetchTableRecordsRetryableMode(String tableName, SourceValueType valueType,
+  public RestAPIResponse fetchTableRecordsRetryableMode(String tableName, SourceValueType valueType,
                                                                   String filterQuery, int offset,
                                                                   int limit) throws ServiceNowAPIException {
-    final List<Map<String, String>> results = new ArrayList<>();
-    Callable<Boolean> fetchRecords = () -> {
-      results.addAll(fetchTableRecords(tableName, valueType, filterQuery, offset, limit));
-      return true;
-    };
+    Callable<RestAPIResponse> fetchRecords = () -> fetchTableRecords(tableName, valueType, filterQuery, offset, limit);
 
-    Retryer<Boolean> retryer = RetryerBuilder.<Boolean>newBuilder()
+    Retryer<RestAPIResponse> retryer = RetryerBuilder.<RestAPIResponse>newBuilder()
       .retryIfException(this::isExceptionRetryable)
       .withWaitStrategy(WaitStrategies.exponentialWait(ServiceNowConstants.WAIT_TIME, TimeUnit.MILLISECONDS))
       .withStopStrategy(StopStrategies.stopAfterAttempt(ServiceNowConstants.MAX_NUMBER_OF_RETRY_ATTEMPTS))
       .build();
 
     try {
-      retryer.call(fetchRecords);
+      return retryer.call(fetchRecords);
     } catch (RetryException | ExecutionException e) {
       throw new ServiceNowAPIException(
           String.format("Data Recovery failed for batch %s to %s.", offset, (offset + limit)),
           e, null, false);
     }
-
-    return results;
   }
 
   /**
@@ -255,8 +255,8 @@ public class ServiceNowTableAPIClientImpl extends RestAPIClient {
   }
 
   @VisibleForTesting
-  public MetadataAPISchemaResponse parseSchemaResponse(String responseBody) {
-    return GSON.fromJson(responseBody, MetadataAPISchemaResponse.class);
+  public MetadataAPISchemaResponse parseSchemaResponse(InputStream responseStream) {
+    return GSON.fromJson(createJsonReader(responseStream), MetadataAPISchemaResponse.class);
   }
 
   /**
@@ -268,8 +268,8 @@ public class ServiceNowTableAPIClientImpl extends RestAPIClient {
    * @throws ServiceNowAPIException
    */
   public Schema fetchTableSchema(String tableName, SourceValueType valueType)
-      throws ServiceNowAPIException {
-    return fetchTableSchema(tableName, getAccessToken(), valueType, schemaType, false);
+    throws ServiceNowAPIException {
+    return fetchTableSchema(tableName, getAccessToken(), valueType, schemaType, true);
   }
 
   private SchemaType getSchemaTypeBasedOnUseConnection(Boolean useConnection) {
@@ -293,7 +293,7 @@ public class ServiceNowTableAPIClientImpl extends RestAPIClient {
    */
   public Schema fetchTableSchema(String tableName, String accessToken, SourceValueType valueType,
                                  SchemaType schemaType, Boolean legacyMapping)
-      throws ServiceNowAPIException {
+    throws ServiceNowAPIException {
     ServiceNowTableAPIRequestBuilder requestBuilder = new ServiceNowTableAPIRequestBuilder(
       this.conf.getRestApiEndpoint(), tableName, true, schemaType)
       .setExcludeReferenceLink(true);
@@ -303,12 +303,16 @@ public class ServiceNowTableAPIClientImpl extends RestAPIClient {
     restAPIResponse = executeGetWithRetries(requestBuilder.build());
     List<ServiceNowColumn> columns = new ArrayList<>();
 
-    if (schemaType == SchemaType.METADATA_API_BASED) {
-      return prepareSchemaWithMetadataAPI(restAPIResponse, columns, tableName, valueType, legacyMapping);
-    } else if (schemaType == SchemaType.SCHEMA_API_BASED) {
-      return prepareSchemaWithSchemaAPI(restAPIResponse, columns, tableName);
-    } else {
-      return prepareStringBasedSchema(restAPIResponse, columns, tableName);
+    try {
+      if (schemaType == SchemaType.METADATA_API_BASED) {
+        return prepareSchemaWithMetadataAPI(restAPIResponse, columns, tableName, valueType, legacyMapping);
+      } else if (schemaType == SchemaType.SCHEMA_API_BASED) {
+        return prepareSchemaWithSchemaAPI(restAPIResponse, columns, tableName, legacyMapping);
+      } else {
+        return prepareStringBasedSchema(restAPIResponse, columns, tableName, legacyMapping);
+      }
+    } catch (IOException exception) {
+      throw new RuntimeException("Error in fetching schema for table " + tableName, exception);
     }
   }
 
@@ -329,9 +333,9 @@ public class ServiceNowTableAPIClientImpl extends RestAPIClient {
    * @throws RuntimeException if the schema response is null or contains no result.
    */
   private Schema prepareSchemaWithSchemaAPI(RestAPIResponse restAPIResponse, List<ServiceNowColumn> columns,
-                                            String tableName) throws ServiceNowAPIException {
+    String tableName, Boolean legacyMapping) throws ServiceNowAPIException, IOException {
     SchemaAPISchemaResponse schemaAPISchemaResponse =
-      GSON.fromJson(restAPIResponse.getResponseBody(), SchemaAPISchemaResponse.class);
+      GSON.fromJson(createJsonReader(restAPIResponse.getResponseStream()), SchemaAPISchemaResponse.class);
 
     if (schemaAPISchemaResponse.getResult() == null || schemaAPISchemaResponse.getResult().isEmpty()) {
       throw new ServiceNowAPIException(
@@ -341,7 +345,7 @@ public class ServiceNowTableAPIClientImpl extends RestAPIClient {
     for (SchemaAPISchemaField field : schemaAPISchemaResponse.getResult()) {
       columns.add(new ServiceNowColumn(field.getName(), field.getInternalType()));
     }
-    return SchemaBuilder.constructSchema(tableName, columns, false);
+    return SchemaBuilder.constructSchema(tableName, columns, legacyMapping);
   }
 
   /**
@@ -363,8 +367,8 @@ public class ServiceNowTableAPIClientImpl extends RestAPIClient {
    * @throws RuntimeException if the response does not contain valid column information.
    */
   private Schema prepareSchemaWithMetadataAPI(RestAPIResponse restAPIResponse, List<ServiceNowColumn> columns,
-    String tableName, SourceValueType valueType, Boolean legacyMapping) throws ServiceNowAPIException {
-    MetadataAPISchemaResponse metadataAPISchemaResponse = parseSchemaResponse(restAPIResponse.getResponseBody());
+    String tableName, SourceValueType valueType, Boolean legacyMapping) throws ServiceNowAPIException, IOException {
+    MetadataAPISchemaResponse metadataAPISchemaResponse = parseSchemaResponse(restAPIResponse.getResponseStream());
 
     if (metadataAPISchemaResponse.getResult() == null || metadataAPISchemaResponse.getResult().getColumns() == null ||
       metadataAPISchemaResponse.getResult().getColumns().isEmpty()) {
@@ -389,6 +393,11 @@ public class ServiceNowTableAPIClientImpl extends RestAPIClient {
       }
     }
     return SchemaBuilder.constructSchema(tableName, columns, legacyMapping);
+  }
+
+  public JsonReader createJsonReader(InputStream inputStream) {
+    Objects.requireNonNull(inputStream, "InputStream must not be null");
+    return new JsonReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8));
   }
 
   /**
@@ -451,8 +460,8 @@ public class ServiceNowTableAPIClientImpl extends RestAPIClient {
       requestBuilder.setContentTypeHeader("application/json");
       requestBuilder.setEntity(entity);
       apiResponse = executePost(requestBuilder.build());
-
       systemID = String.valueOf(getSystemId(apiResponse));
+      apiResponse.close();
     } catch (IOException e) {
       throw new ServiceNowAPIException("Error in creating a new record", e, null, false);
     }
@@ -482,15 +491,17 @@ public class ServiceNowTableAPIClientImpl extends RestAPIClient {
       apiResponse = executePost(requestBuilder.build());
 
       systemID = String.valueOf(getSystemId(apiResponse));
+      apiResponse.close();
     } catch (IOException e) {
       throw new ServiceNowAPIException("Error in creating a new record", e, null, false);
     }
     return systemID;
   }
 
-  private String getSystemId(RestAPIResponse restAPIResponse) {
-    CreateRecordAPIResponse apiResponse = GSON.fromJson(restAPIResponse.getResponseBody(),
-                                                           CreateRecordAPIResponse.class);
+  private String getSystemId(RestAPIResponse restAPIResponse) throws IOException {
+    CreateRecordAPIResponse apiResponse = GSON.fromJson(
+      new InputStreamReader(restAPIResponse.getResponseStream(), StandardCharsets.UTF_8),
+        CreateRecordAPIResponse.class);
     return apiResponse.getResult().get(ServiceNowConstants.SYSTEM_ID).toString();
   }
 
@@ -501,8 +512,8 @@ public class ServiceNowTableAPIClientImpl extends RestAPIClient {
    * @param tableName The ServiceNow table name
    * @param query The query
    */
-  public Map<String, String> getRecordFromServiceNowTable(String tableName, String query)
-      throws ServiceNowAPIException {
+  public JsonObject getRecordFromServiceNowTable(String tableName, String query)
+    throws ServiceNowAPIException, IOException {
 
     ServiceNowTableAPIRequestBuilder requestBuilder = new ServiceNowTableAPIRequestBuilder(
       this.conf.getRestApiEndpoint(), tableName, false, schemaType)
@@ -513,7 +524,8 @@ public class ServiceNowTableAPIClientImpl extends RestAPIClient {
     requestBuilder.setAuthHeader(accessToken);
     restAPIResponse = executeGetWithRetries(requestBuilder.build());
 
-    APIResponse apiResponse = GSON.fromJson(restAPIResponse.getResponseBody(), APIResponse.class);
+    APIResponse apiResponse = GSON.fromJson(
+      new InputStreamReader(restAPIResponse.getResponseStream(), StandardCharsets.UTF_8), APIResponse.class);
     return apiResponse.getResult().get(0);
   }
 
@@ -530,16 +542,42 @@ public class ServiceNowTableAPIClientImpl extends RestAPIClient {
    *
    * @throws RuntimeException if the schema response is null or contains no result.
    */
-  private Schema prepareStringBasedSchema(RestAPIResponse restAPIResponse, List<ServiceNowColumn> columns,
-                                          String tableName) {
-    List<Map<String, String>> result = parseResponseToResultListOfMap(restAPIResponse.getResponseBody());
-    if (result != null && !result.isEmpty()) {
-      Map<String, String> firstRecord = result.get(0);
-      for (String key : firstRecord.keySet()) {
-        columns.add(new ServiceNowColumn(key, "string"));
+    private Schema prepareStringBasedSchema(RestAPIResponse restAPIResponse, List<ServiceNowColumn> columns,
+                                          String tableName, Boolean legacyMapping) throws IOException {
+      InputStream in = restAPIResponse.getResponseStream();
+      JsonReader reader = new JsonReader(new InputStreamReader(in, StandardCharsets.UTF_8));
+      JsonObject firstRecord;
+      try {
+        firstRecord = getFirstRecord(reader);
+        restAPIResponse.close();
+      } catch (IOException e) {
+        throw new RuntimeException("Failed to parse schema for table: " + tableName, e);
       }
-      return SchemaBuilder.constructSchema(tableName, columns, false);
+      if (firstRecord != null) {
+      firstRecord.entrySet().forEach(entry ->
+        columns.add(new ServiceNowColumn(entry.getKey(), "string"))
+      );
+      return SchemaBuilder.constructSchema(tableName, columns, legacyMapping);
     }
+    return null;
+  }
+
+  public JsonObject getFirstRecord(JsonReader reader) throws IOException {
+    reader.beginObject();
+    while (reader.hasNext()) {
+      String name = reader.nextName();
+      if (name.equals(ServiceNowConstants.RESULT)) {
+        reader.beginArray();
+        if (reader.hasNext()) {
+          // ONLY parse the first object into memory
+          return GSON.fromJson(reader, JsonObject.class);
+        }
+        reader.endArray();
+      } else {
+        reader.skipValue();
+      }
+    }
+    reader.endObject();
     return null;
   }
 

--- a/src/main/java/io/cdap/plugin/servicenow/connector/ServiceNowConnector.java
+++ b/src/main/java/io/cdap/plugin/servicenow/connector/ServiceNowConnector.java
@@ -16,6 +16,8 @@
 package io.cdap.plugin.servicenow.connector;
 
 import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.gson.stream.JsonReader;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.annotation.Plugin;
@@ -55,6 +57,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -103,7 +108,7 @@ public class ServiceNowConnector implements DirectConnector {
    * Browse Details for the given AccessToken.
    */
   public BrowseDetail browse(ConnectorContext connectorContext,
-                             String accessToken) throws ServiceNowAPIException {
+                             String accessToken) throws ServiceNowAPIException, IOException {
     int count = 0;
     FailureCollector collector = connectorContext.getFailureCollector();
     config.validateCredentialsFields(collector);
@@ -126,7 +131,7 @@ public class ServiceNowConnector implements DirectConnector {
   /**
    * @return the list of tables.
    */
-  private TableList listTables(String accessToken) throws ServiceNowAPIException {
+  private TableList listTables(String accessToken) throws ServiceNowAPIException, IOException {
     ServiceNowTableAPIRequestBuilder requestBuilder = new ServiceNowTableAPIRequestBuilder(
       config.getRestApiEndpoint(), OBJECT_TABLE_LIST, false, SchemaType.SCHEMA_API_BASED);
     requestBuilder.setAuthHeader(accessToken);
@@ -135,7 +140,7 @@ public class ServiceNowConnector implements DirectConnector {
     ServiceNowTableAPIClientImpl serviceNowTableAPIClient = new ServiceNowTableAPIClientImpl(config, true);
     RestAPIResponse apiResponse =
         serviceNowTableAPIClient.executeGetWithRetries(requestBuilder.build());
-    return GSON.fromJson(apiResponse.getResponseBody(), TableList.class);
+    return GSON.fromJson(serviceNowTableAPIClient.createJsonReader(apiResponse.getResponseStream()), TableList.class);
   }
 
   public ConnectorSpec generateSpec(ConnectorContext connectorContext, ConnectorSpecRequest connectorSpecRequest) {
@@ -172,7 +177,7 @@ public class ServiceNowConnector implements DirectConnector {
   }
 
   private List<StructuredRecord> getTableData(String tableName, int limit)
-      throws OAuthProblemException, OAuthSystemException, ServiceNowAPIException {
+    throws OAuthProblemException, OAuthSystemException, ServiceNowAPIException, IOException {
     ServiceNowTableAPIRequestBuilder requestBuilder = new ServiceNowTableAPIRequestBuilder(
       config.getRestApiEndpoint(), tableName, false, SchemaType.SCHEMA_API_BASED)
       .setExcludeReferenceLink(true)
@@ -183,22 +188,40 @@ public class ServiceNowConnector implements DirectConnector {
     requestBuilder.setAuthHeader(accessToken);
     requestBuilder.setResponseHeaders(ServiceNowConstants.HEADER_NAME_TOTAL_COUNT);
     RestAPIResponse apiResponse = serviceNowTableAPIClient.executeGetWithRetries(requestBuilder.build());
-    List<Map<String, String>> result = serviceNowTableAPIClient.parseResponseToResultListOfMap
-      (apiResponse.getResponseBody());
+    InputStream in = apiResponse.getResponseStream();
+    JsonReader reader = new JsonReader(new InputStreamReader(in, StandardCharsets.UTF_8));
     List<StructuredRecord> recordList = new ArrayList<>();
     Schema schema = getSchema(tableName);
     if (schema != null) {
       List<Schema.Field> tableFields = schema.getFields();
-      for (int i = 0; i < result.size(); i++) {
-        StructuredRecord.Builder recordBuilder = StructuredRecord.builder(schema);
-        for (Schema.Field field : tableFields) {
-          String fieldName = field.getName();
-          ServiceNowRecordConverter.convertToValue(fieldName, field.getSchema(), result.get(i), recordBuilder, false);
+      try {
+        reader.beginObject();
+        while (reader.hasNext()) {
+          String name = reader.nextName();
+          if (name.equals(ServiceNowConstants.RESULT)) {
+            reader.beginArray();
+            while (reader.hasNext()) {
+              JsonObject jsonObject = GSON.fromJson(reader, JsonObject.class);
+              StructuredRecord.Builder recordBuilder = StructuredRecord.builder(schema);
+              for (Schema.Field field : tableFields) {
+                String fieldName = field.getName();
+                ServiceNowRecordConverter.convertToValue(fieldName, field.getSchema(), jsonObject, recordBuilder,
+                  false);
+              }
+              StructuredRecord structuredRecord = recordBuilder.build();
+              recordList.add(structuredRecord);
+            }
+            reader.endArray();
+          } else {
+            reader.skipValue();
+          }
         }
-        StructuredRecord structuredRecord = recordBuilder.build();
-        recordList.add(structuredRecord);
+        reader.endObject();
+      } catch (IOException e) {
+        throw new RuntimeException("Error reading JSON response for table " + tableName, e);
       }
     }
+    apiResponse.close();
     return recordList;
 
   }

--- a/src/main/java/io/cdap/plugin/servicenow/connector/ServiceNowRecordConverter.java
+++ b/src/main/java/io/cdap/plugin/servicenow/connector/ServiceNowRecordConverter.java
@@ -16,6 +16,7 @@
 package io.cdap.plugin.servicenow.connector;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.gson.JsonObject;
 import io.cdap.cdap.api.data.format.StructuredRecord;
 import io.cdap.cdap.api.data.format.UnexpectedFormatException;
 import io.cdap.cdap.api.data.schema.Schema;
@@ -27,6 +28,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -83,9 +85,10 @@ public class ServiceNowRecordConverter {
       DateTimeFormatter.ofPattern("HH:mm")
     ));
 
-  public static void convertToValue(String fieldName, Schema fieldSchema, Map<String, String> record,
-    StructuredRecord.Builder recordBuilder, Boolean legacyMapping) {
-    String fieldValue = record.get(fieldName);
+  public static void convertToValue(String fieldName, Schema fieldSchema, JsonObject record,
+                                    StructuredRecord.Builder recordBuilder, Boolean legacyMapping) {
+    String fieldValue = record.has(fieldName) && !record.get(fieldName).isJsonNull() ? record.get(fieldName)
+      .getAsString() : null;
     if (fieldValue == null || fieldValue.isEmpty()) {
       // Set 'null' value as it is
       recordBuilder.set(fieldName, null);

--- a/src/main/java/io/cdap/plugin/servicenow/model/APIResponse.java
+++ b/src/main/java/io/cdap/plugin/servicenow/model/APIResponse.java
@@ -16,6 +16,8 @@
 
 package io.cdap.plugin.servicenow.model;
 
+import com.google.gson.JsonObject;
+
 import java.util.List;
 import java.util.Map;
 
@@ -24,9 +26,9 @@ import java.util.Map;
  */
 public class APIResponse {
   
-  private List<Map<String, String>> result;
+  private List<JsonObject> result;
 
-  public List<Map<String, String>> getResult() {
+  public List<JsonObject> getResult() {
     return result;
   }
 

--- a/src/main/java/io/cdap/plugin/servicenow/restapi/RestAPIClient.java
+++ b/src/main/java/io/cdap/plugin/servicenow/restapi/RestAPIClient.java
@@ -55,16 +55,55 @@ import java.util.concurrent.TimeUnit;
 public abstract class RestAPIClient {
   private static final Logger LOG = LoggerFactory.getLogger(RestAPIClient.class);
   
-  /* Connect Timout in ms for establishing the conenction with the server */
+  /* Connect Timeout in ms for establishing the connection with the server */
   private static final int DEFAULT_CONNECT_TIMEOUT_MS = 120000;
 
   /* Read Timeout in ms for waiting for data after the connection is established */
-  private static final int DEFAULT_READ_TIMEOUT_MS = 300000;
+  private static final int DEFAULT_READ_TIMEOUT_MS = 120000;
 
+  /* Maximum total connections. */
+  private static final int MAX_CONNECTIONS = 200;
+
+  /** The maximum time a connection is allowed to live in the pool before being retired.
+   * Helps avoid "stale connection" errors during long-running pipelines. */
+  private static final long CONNECTION_TTL_MINUTES = 5;
+
+  /** The interval at which idle connections are scanned and closed by the background monitor. */
+  private static final long IDLE_EVICTION_SECONDS = 60;
+  
   private static final RequestConfig requestConfig = RequestConfig.custom()
     .setConnectTimeout(DEFAULT_CONNECT_TIMEOUT_MS)
     .setSocketTimeout(DEFAULT_READ_TIMEOUT_MS)
     .build();
+
+  private final CloseableHttpClient httpClient;
+
+  /* Default constructor to initialize the HttpClient. */
+  protected RestAPIClient() {
+    this.httpClient = getHttpClient();
+  }
+
+  /* Lazy Holder to protect unit tests from premature static initialization errors. */
+  static class HttpClientHolder {
+    static final CloseableHttpClient HTTP_CLIENT = createClient();
+
+    private static CloseableHttpClient createClient() {
+      return HttpClientBuilder.create()
+        .setMaxConnTotal(MAX_CONNECTIONS)
+        .setMaxConnPerRoute(MAX_CONNECTIONS)
+        .setConnectionTimeToLive(CONNECTION_TTL_MINUTES, TimeUnit.MINUTES)
+        .evictIdleConnections(IDLE_EVICTION_SECONDS, TimeUnit.SECONDS)
+        .setDefaultRequestConfig(RequestConfig.custom().setConnectTimeout(DEFAULT_CONNECT_TIMEOUT_MS)
+           .setSocketTimeout(DEFAULT_READ_TIMEOUT_MS).build())
+        .build();
+    }
+  }
+  /**
+   * Protected method to return the HttpClient instance. This is used to mock the HttpClient in unit tests.
+   */
+  protected CloseableHttpClient getHttpClient() {
+    return HttpClientHolder.HTTP_CLIENT;
+  }
 
   /**
    * Executes the Rest API request and returns the response.
@@ -76,10 +115,9 @@ public abstract class RestAPIClient {
     HttpGet httpGet = new HttpGet(request.getUrl());
     request.getHeaders().entrySet().forEach(e -> httpGet.addHeader(e.getKey(), e.getValue()));
 
-    try (CloseableHttpClient httpClient = HttpClientBuilder.create().setDefaultRequestConfig(requestConfig).build()) {
-      try (CloseableHttpResponse httpResponse = httpClient.execute(httpGet)) {
-        return RestAPIResponse.parse(httpResponse, request.getResponseHeaders());
-      }
+    try {
+      CloseableHttpResponse httpResponse = httpClient.execute(httpGet);
+      return RestAPIResponse.parse(httpResponse, request.getResponseHeaders());
     } catch (ConnectTimeoutException | SocketException e) {
       ServiceNowAPIException exception = new ServiceNowAPIException(e, null);
       return new RestAPIResponse(Collections.emptyMap(), null, exception);
@@ -154,11 +192,13 @@ public abstract class RestAPIClient {
     // We're retrying all transport exceptions while executing the HTTP POST method and the generic transport
     // exceptions in HttpClient are represented by the standard java.io.IOException class
     // https://hc.apache.org/httpclient-legacy/exception-handling.html
-    try (CloseableHttpClient httpClient = HttpClientBuilder.create().setDefaultRequestConfig(requestConfig).build()) {
-      try (CloseableHttpResponse httpResponse = httpClient.execute(httpPost)) {
+      try {
+        CloseableHttpResponse httpResponse = httpClient.execute(httpPost);
         return RestAPIResponse.parse(httpResponse, request.getResponseHeaders());
+      } catch (ConnectTimeoutException | SocketException e) {
+        ServiceNowAPIException exception = new ServiceNowAPIException(e, null);
+        return new RestAPIResponse(Collections.emptyMap(), null, exception);
       }
-    }
   }
   /**
    * Generates access token and returns the same.

--- a/src/main/java/io/cdap/plugin/servicenow/restapi/RestAPIResponse.java
+++ b/src/main/java/io/cdap/plugin/servicenow/restapi/RestAPIResponse.java
@@ -21,11 +21,15 @@ import com.google.gson.JsonObject;
 import io.cdap.plugin.servicenow.apiclient.ServiceNowAPIException;
 import io.cdap.plugin.servicenow.util.ServiceNowConstants;
 import org.apache.http.Header;
+import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
-import org.apache.http.util.EntityUtils;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -40,26 +44,32 @@ import javax.annotation.Nullable;
  * Pojo class to capture the API response.
  */
 public class RestAPIResponse {
+  private static final Logger LOG = LoggerFactory.getLogger(RestAPIResponse.class);
   private static final Gson GSON = new Gson();
   private static final String HTTP_ERROR_MESSAGE = "Http call to ServiceNow instance returned status code %d.";
   private static final String REST_ERROR_MESSAGE = "Rest Api response has errors. Error message: %s.";
   private static final Set<Integer> SUCCESS_CODES = new HashSet<>(Arrays.asList(HttpStatus.SC_CREATED,
                                                                                 HttpStatus.SC_OK));
   private final Map<String, String> headers;
-  private final String responseBody;
   @Nullable private final ServiceNowAPIException exception;
 
+  // Keep reference of HttpResponse for error handling, as it needs to be closed after consuming the response stream.
+  private HttpResponse httpResponse;
+
   public RestAPIResponse(
-      Map<String, String> headers,
-      @Nullable String responseBody,
-      @Nullable ServiceNowAPIException exception) {
+    Map<String, String> headers,
+    HttpResponse httpResponse,
+    @Nullable ServiceNowAPIException exception) {
     this.headers = headers;
-    this.responseBody = responseBody;
+    this.httpResponse = httpResponse;
     this.exception = exception;
   }
 
   /**
    * Parses HttpResponse into RestAPIResponse object when no errors occur.
+   * The RESTAPIResponse contains the HTTP response body as a stream. This stream is:
+   * single-use, forward-only and owned by the caller. Caller is responsible for consuming and closing it.
+   *
    * Throws a {@link ServiceNowAPIException}.
    *
    * @param httpResponse The HttpResponse object to parse
@@ -80,18 +90,37 @@ public class RestAPIResponse {
 
     ServiceNowAPIException serviceNowAPIException = validateHttpResponse(httpResponse);
     if (serviceNowAPIException != null) {
+      return new RestAPIResponse(headers, httpResponse, serviceNowAPIException);
+    }
+    return new RestAPIResponse(headers, httpResponse, null);
+  }
+
+  public void close() throws IOException {
+    try {
+      InputStream responseStream = getResponseStream();
+      if (responseStream != null) {
+        LOG.info("Closing response stream");
+        responseStream.close();
+      }
+    } finally {
+      if (httpResponse instanceof CloseableHttpResponse) {
+        LOG.info("Closing HttpResponse");
+        ((CloseableHttpResponse) httpResponse).close();
+      }
+    }
+  }
+
+  /*public static RestAPIResponse prepareResponse(HttpResponse httpResponse, Map<String, String> headers,
+      ServiceNowAPIException serviceNowAPIException) throws IOException {
+    HttpEntity httpEntity = httpResponse.getEntity();
+    InputStream inputStream;
+    if (httpEntity != null) {
+      inputStream = httpEntity.getContent();
+      return new RestAPIResponse(headers, inputStream, serviceNowAPIException);
+    } else {
       return new RestAPIResponse(headers, null, serviceNowAPIException);
     }
-
-    String responseBody = null;
-    try {
-      responseBody = EntityUtils.toString(httpResponse.getEntity());
-    } catch (IOException e) {
-      return new RestAPIResponse(headers, null, new ServiceNowAPIException(e, httpResponse));
-    }
-    serviceNowAPIException = validateRestApiResponse(httpResponse, responseBody);
-    return new RestAPIResponse(headers, responseBody, serviceNowAPIException);
-  }
+  }*/
 
   public static RestAPIResponse parse(HttpResponse httpResponse) throws IOException {
     return parse(httpResponse, new String[0]);
@@ -127,16 +156,19 @@ public class RestAPIResponse {
   }
 
   @Nullable
-  public String getResponseBody() {
-    return responseBody;
-  }
-
-  @Nullable
   public ServiceNowAPIException getException() {
     return exception;
   }
 
   public boolean hasException() {
     return exception != null;
+  }
+
+  public InputStream getResponseStream() throws IOException {
+    if (httpResponse == null) {
+      return null;
+    }
+    HttpEntity entity = httpResponse.getEntity();
+    return (entity != null) ? entity.getContent() : null;
   }
 }

--- a/src/main/java/io/cdap/plugin/servicenow/sink/service/ServiceNowSinkAPIRequestImpl.java
+++ b/src/main/java/io/cdap/plugin/servicenow/sink/service/ServiceNowSinkAPIRequestImpl.java
@@ -25,6 +25,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import com.google.gson.stream.JsonReader;
 import io.cdap.cdap.api.retry.RetryableException;
 import io.cdap.plugin.servicenow.apiclient.ServiceNowAPIException;
 import io.cdap.plugin.servicenow.apiclient.ServiceNowTableAPIClientImpl;
@@ -43,6 +44,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Base64;
@@ -121,7 +123,8 @@ public class ServiceNowSinkAPIRequestImpl {
       requestBuilder.setEntity(stringEntity);
       apiResponse = restApi.executePost(requestBuilder.build());
 
-      JsonObject responseJSON = jsonParser.parse(apiResponse.getResponseBody()).getAsJsonObject();
+      JsonObject responseJSON = jsonParser.parse(getJsonReader(apiResponse))
+          .getAsJsonObject().getAsJsonObject();
       JsonArray servicedRequestsArray = responseJSON.get(ServiceNowConstants.SERVICED_REQUESTS).getAsJsonArray();
       JsonElement failedRequestId = null;
       for (int i = 0; i < servicedRequestsArray.size(); i++) {
@@ -166,6 +169,14 @@ public class ServiceNowSinkAPIRequestImpl {
       LOG.error("Error while connecting to ServiceNow", e.getMessage());
       throw new ServiceNowAPIException("Error while connecting to ServiceNow", e, null, true);
     }
+  }
+
+  private JsonReader getJsonReader(RestAPIResponse apiResponse) throws IOException {
+    InputStreamReader inputStreamReader = new InputStreamReader(apiResponse.getResponseStream(),
+      StandardCharsets.UTF_8);
+    JsonReader jsonReader = new JsonReader(inputStreamReader);
+    jsonReader.setLenient(true);
+    return jsonReader;
   }
 
   private ServiceNowBatchRequest getPayloadRequest(Map<String, RestRequest> restRequests) {

--- a/src/main/java/io/cdap/plugin/servicenow/source/ServiceNowBaseRecordReader.java
+++ b/src/main/java/io/cdap/plugin/servicenow/source/ServiceNowBaseRecordReader.java
@@ -16,20 +16,33 @@
 
 package io.cdap.plugin.servicenow.source;
 
+import com.google.gson.Gson;
+import com.google.gson.JsonIOException;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSyntaxException;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
 import io.cdap.cdap.api.data.format.StructuredRecord;
 import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.plugin.servicenow.apiclient.ServiceNowAPIException;
+import io.cdap.plugin.servicenow.restapi.RestAPIResponse;
+import io.cdap.plugin.servicenow.util.ServiceNowConstants;
 import org.apache.hadoop.io.NullWritable;
 import org.apache.hadoop.mapreduce.RecordReader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.Iterator;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Base Record reader class that provides a basic structure for Derived Record Reader classes.
  */
 public abstract class ServiceNowBaseRecordReader extends RecordReader<NullWritable, StructuredRecord> {
+  private static final Logger LOG = LoggerFactory.getLogger(ServiceNowRecordReader.class);
   protected ServiceNowInputSplit split;
   protected int pos;
   protected List<Schema.Field> tableFields;
@@ -37,14 +50,142 @@ public abstract class ServiceNowBaseRecordReader extends RecordReader<NullWritab
 
   protected String tableName;
   protected String tableNameField;
-  protected List<Map<String, String>> results;
-  protected Iterator<Map<String, String>> iterator;
-  protected Map<String, String> row;
+  protected JsonObject row;
+  protected final Gson gson = new Gson();
+  protected JsonReader jsonReader = null;
+  protected RestAPIResponse currentResponse = null;
 
   public ServiceNowBaseRecordReader() {
   }
 
-  public abstract boolean nextKeyValue() throws IOException;
+  /**
+   * This method reads the next key/value pair from the input.
+   * <p>
+   * The nextKeyValue() uses the jsonReader to read the next record from the current page.
+   * <p>
+   * Returns true, when it assigned `row` to the next record.
+   * Returns false, only when there are no more pages/records (i.e., openNextPage() returns false).
+   */
+  public boolean nextKeyValue() throws IOException {
+    // Ensure we have an active page/jsonReader
+    if (jsonReader == null) {
+      // Need to open the next page
+      boolean pageOpened;
+      try {
+        pageOpened = openNextPage();
+      } catch (ServiceNowAPIException e) {
+        throw new IOException("Exception in nextKeyValue" + tableName, e);
+      }
+      if (!pageOpened) {
+        // No more pages
+        return false;
+      }
+    }
+
+    // At this point jsonReader is positioned inside the "result" array.
+    JsonToken token = jsonReader.peek();
+
+    if (token == JsonToken.BEGIN_OBJECT) {
+      LOG.debug("Reading record object for table {} at position {}", tableName, pos);
+      try {
+        row = gson.fromJson(jsonReader, JsonObject.class); // assign row
+      } catch (JsonIOException | JsonSyntaxException e) {
+        throw new IOException("Error parsing JSON record for table " + tableName + " at position " + pos, e);
+      }
+      pos++;
+      return true;
+    } else if (token == JsonToken.END_ARRAY) {
+      // This is the only "Normal" end of a page
+      closeCurrentPage();
+      return false;
+    } else {
+      // If we get here, the JSON is malformed or truncated
+      throw new IOException("Unexpected JSON token " + token + " at position " + pos);
+    }
+  }
+  
+  public boolean openNextPage() throws IOException, ServiceNowAPIException {
+    closeCurrentPage();
+    this.currentResponse = fetchData();
+    InputStream in = this.currentResponse.getResponseStream();
+    if (in == null) {
+      closeCurrentPage();
+      return false;
+    }
+    this.jsonReader = new JsonReader(new InputStreamReader(in, StandardCharsets.UTF_8));
+    this.jsonReader.setLenient(true);
+
+    // Position the reader to the "result" array: { "result": [ ... ], ... }
+    try {
+      JsonToken top;
+      try {
+        top = jsonReader.peek();
+        LOG.debug("Peeking JSON token for table {}: {}", tableName, top);
+      } catch (IOException e) {
+        closeCurrentPage();
+        throw new IOException("Unexpected closure of stream while peeking JSON token for table {}" + tableName, e);
+      }
+      if (top == JsonToken.BEGIN_OBJECT) {
+        jsonReader.beginObject();
+        while (jsonReader.hasNext()) {
+          String name = jsonReader.nextName();
+          if (name.equals(ServiceNowConstants.RESULT)) {
+            if (jsonReader.peek() == JsonToken.BEGIN_ARRAY) {
+              jsonReader.beginArray();
+              return true;
+            } else {
+              jsonReader.skipValue();
+              break;
+            }
+          } else {
+            jsonReader.skipValue();
+          }
+        }
+      } else if (top == JsonToken.BEGIN_ARRAY) {
+        jsonReader.beginArray();
+        return true;
+      } else if (jsonReader.peek() == JsonToken.END_ARRAY) {
+        // empty result array — treat as no-more-data for this split/page
+        LOG.debug("openNextPage: found empty result array (no records). Closing and returning false.");
+        jsonReader.endArray();
+        // cleanup
+        closeCurrentPage();
+        return false;
+      }
+    } catch (IOException e) {
+      closeCurrentPage();
+      throw e;
+    }
+
+    // No "result" array not found, close the current page and return false
+    closeCurrentPage();
+    return false;
+  }
+
+  public void closeCurrentPage() {
+    LOG.info("Closing current page for table {}", tableName);
+    if (this.jsonReader != null) {
+      try {
+        this.jsonReader.close();
+      } catch (IOException e) {
+        LOG.warn("Error closing JSON reader", e);
+      } finally {
+        this.jsonReader = null;
+      }
+    }
+
+    if (this.currentResponse != null) {
+      try {
+        this.currentResponse.close();
+      } catch (IOException e) {
+        LOG.warn("Error closing RestAPIResponse for table {}", tableName, e);
+      } finally {
+        this.currentResponse = null;
+      }
+    }
+  }
+
+  abstract RestAPIResponse fetchData() throws ServiceNowAPIException;
 
   public NullWritable getCurrentKey() {
     return NullWritable.get();
@@ -56,6 +197,11 @@ public abstract class ServiceNowBaseRecordReader extends RecordReader<NullWritab
     return pos / (float) split.getLength();
   }
 
+  public int getPos() {
+    return pos;
+  }
+
   public void close() throws IOException {
+    closeCurrentPage();
   }
 }

--- a/src/main/java/io/cdap/plugin/servicenow/source/ServiceNowMultiRecordReader.java
+++ b/src/main/java/io/cdap/plugin/servicenow/source/ServiceNowMultiRecordReader.java
@@ -17,17 +17,30 @@
 package io.cdap.plugin.servicenow.source;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
 import io.cdap.cdap.api.data.format.StructuredRecord;
 import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.plugin.servicenow.apiclient.ServiceNowAPIException;
 import io.cdap.plugin.servicenow.apiclient.ServiceNowTableAPIClientImpl;
 import io.cdap.plugin.servicenow.connector.ServiceNowRecordConverter;
+import io.cdap.plugin.servicenow.restapi.RestAPIResponse;
+import io.cdap.plugin.servicenow.util.ServiceNowConstants;
 import org.apache.hadoop.mapreduce.InputSplit;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Record reader that reads the entire contents of a ServiceNow table.
@@ -55,26 +68,6 @@ public class ServiceNowMultiRecordReader extends ServiceNowBaseRecordReader {
   }
 
   @Override
-  public boolean nextKeyValue() throws IOException {
-    try {
-      if (results == null) {
-        fetchData();
-      }
-
-      if (!iterator.hasNext()) {
-        return false;
-      }
-
-      row = iterator.next();
-
-      pos++;
-    } catch (Exception e) {
-      throw new IOException("Exception in nextKeyValue", e);
-    }
-    return true;
-  }
-
-  @Override
   public StructuredRecord getCurrentValue() throws IOException {
     StructuredRecord.Builder recordBuilder = StructuredRecord.builder(schema);
     recordBuilder.set(tableNameField, tableName);
@@ -91,14 +84,15 @@ public class ServiceNowMultiRecordReader extends ServiceNowBaseRecordReader {
     return recordBuilder.build();
   }
 
+  @Override
   @VisibleForTesting
-  void fetchData() throws ServiceNowAPIException {
+  RestAPIResponse fetchData() throws ServiceNowAPIException {
     // Get the table data
-    results = restApi.fetchTableRecordsRetryableMode(tableName, multiSourcePluginConf.getValueType(),
-            split.getFilterQuery(), split.getOffset(),
-            multiSourcePluginConf.getPageSize());
+    RestAPIResponse restAPIResponse = restApi.fetchTableRecordsRetryableMode(tableName,
+      multiSourcePluginConf.getValueType(), split.getFilterQuery(),
+        split.getOffset(), multiSourcePluginConf.getPageSize());
 
-    iterator = results.iterator();
+    return restAPIResponse;
   }
 
   private void fetchSchema(ServiceNowTableAPIClientImpl restApi) {

--- a/src/main/java/io/cdap/plugin/servicenow/source/ServiceNowRecordReader.java
+++ b/src/main/java/io/cdap/plugin/servicenow/source/ServiceNowRecordReader.java
@@ -21,6 +21,7 @@ import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.plugin.servicenow.apiclient.ServiceNowAPIException;
 import io.cdap.plugin.servicenow.apiclient.ServiceNowTableAPIClientImpl;
 import io.cdap.plugin.servicenow.connector.ServiceNowRecordConverter;
+import io.cdap.plugin.servicenow.restapi.RestAPIResponse;
 import io.cdap.plugin.servicenow.util.ServiceNowTableInfo;
 import io.cdap.plugin.servicenow.util.SourceQueryMode;
 import org.apache.hadoop.mapreduce.InputSplit;
@@ -64,27 +65,6 @@ public class ServiceNowRecordReader extends ServiceNowBaseRecordReader {
   }
 
   @Override
-  public boolean nextKeyValue() throws IOException {
-    try {
-      if (results == null) {
-        fetchData();
-      }
-
-      if (!iterator.hasNext()) {
-        return false;
-      }
-
-      row = iterator.next();
-
-      pos++;
-    } catch (Exception e) {
-      LOG.error("Error in nextKeyValue", e);
-      throw new IOException("Exception in nextKeyValue", e);
-    }
-    return true;
-  }
-
-  @Override
   public StructuredRecord getCurrentValue() throws IOException {
     StructuredRecord.Builder recordBuilder = StructuredRecord.builder(schema);
 
@@ -105,14 +85,15 @@ public class ServiceNowRecordReader extends ServiceNowBaseRecordReader {
     return recordBuilder.build();
   }
 
-  private void fetchData() throws ServiceNowAPIException {
+    @Override
+    RestAPIResponse fetchData() throws ServiceNowAPIException {
+    LOG.info("Fetching data for table: {}, with offset: {} and page size: {}", tableName, split.getOffset(),
+      pluginConf.getPageSize());
     // Get the table data
-    results = restApi.fetchTableRecordsRetryableMode(tableName, pluginConf.getValueType(), split.getFilterQuery(),
-            split.getOffset(),
-                                                     pluginConf.getPageSize());
-    LOG.debug("Results size={}", results.size());
+    RestAPIResponse restAPIResponse = restApi.fetchTableRecordsRetryableMode(tableName, pluginConf.getValueType(),
+     split.getFilterQuery() , split.getOffset(), pluginConf.getPageSize());
 
-    iterator = results.iterator();
+    return restAPIResponse;
   }
 
   protected void initialize(InputSplit split) {

--- a/src/main/java/io/cdap/plugin/servicenow/util/ServiceNowConstants.java
+++ b/src/main/java/io/cdap/plugin/servicenow/util/ServiceNowConstants.java
@@ -199,7 +199,7 @@ public interface ServiceNowConstants {
   /**
    * The wait time for API retry in milliseconds.
    */
-  int WAIT_TIME = 120000;
+  int WAIT_TIME = 300000;
   
   /**
    * The maximum number of retry attempts.

--- a/src/test/java/io/cdap/plugin/servicenow/apiclient/ServiceNowTableAPIClientImplTest.java
+++ b/src/test/java/io/cdap/plugin/servicenow/apiclient/ServiceNowTableAPIClientImplTest.java
@@ -8,13 +8,20 @@ import io.cdap.plugin.servicenow.util.SourceValueType;
 
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
+import org.apache.http.HttpVersion;
 import org.apache.http.StatusLine;
+import org.apache.http.entity.InputStreamEntity;
+import org.apache.http.message.BasicHttpResponse;
+import org.apache.http.message.BasicStatusLine;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.mockito.Mockito;
 
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -34,17 +41,18 @@ public class ServiceNowTableAPIClientImplTest {
       put("keyTest", "valueTest");
     }});
     HttpResponse mockResponse = Mockito.mock(HttpResponse.class);
+    RestAPIResponse mockApiResponse = new RestAPIResponse(Collections.emptyMap(), null, null);
     Mockito.when(mockResponse.getStatusLine()).thenReturn(Mockito.mock(StatusLine.class));
     Mockito.when(mockResponse.getStatusLine().getStatusCode()).thenReturn(HttpStatus.SC_REQUEST_TIMEOUT);
     Mockito.doThrow(new ServiceNowAPIException("Retryable Error", mockResponse))
-            .doReturn(mockResults)
+            .doReturn(mockApiResponse)
                 .when(implSpy).fetchTableRecords(
             Mockito.anyString(),
             Mockito.any(),
             Mockito.anyString(),
             Mockito.anyInt(),
             Mockito.anyInt());
-    List<Map<String, String>> receivedResults =
+    RestAPIResponse restAPIResponse =
         implSpy.fetchTableRecordsRetryableMode(
             "test", SourceValueType.SHOW_DISPLAY_VALUE, "", 0, 0);
     Mockito.verify(implSpy, Mockito.times(2)).fetchTableRecords(
@@ -53,7 +61,7 @@ public class ServiceNowTableAPIClientImplTest {
         Mockito.anyString(),
         Mockito.anyInt(),
         Mockito.anyInt());
-    Assert.assertEquals(receivedResults, mockResults);
+    Assert.assertEquals(restAPIResponse, mockApiResponse);
   }
 
   @Test
@@ -63,11 +71,12 @@ public class ServiceNowTableAPIClientImplTest {
     ServiceNowTableAPIClientImpl impl = new ServiceNowTableAPIClientImpl(mockConfig, true);
     ServiceNowTableAPIClientImpl implSpy = Mockito.spy(impl);
     HttpResponse mockResponse = Mockito.mock(HttpResponse.class);
+    RestAPIResponse mockAPIResponse = new RestAPIResponse(Collections.emptyMap(), null, null);
     Mockito.when(mockResponse.getStatusLine()).thenReturn(Mockito.mock(StatusLine.class));
     Mockito.when(mockResponse.getStatusLine().getStatusCode()).thenReturn(HttpStatus.SC_INTERNAL_SERVER_ERROR);
     Mockito.doThrow(
         new ServiceNowAPIException("Non-retryable Error", mockResponse))
-        .doReturn(new ArrayList<>())
+        .doReturn(mockAPIResponse)
         .when(implSpy).fetchTableRecords(
             Mockito.anyString(),
             Mockito.any(),
@@ -101,7 +110,12 @@ public class ServiceNowTableAPIClientImplTest {
       "    }\n" +
       "  ]\n" +
       "}";
-    RestAPIResponse mockResponse = new RestAPIResponse(Collections.emptyMap(), jsonResponse, null);
+    byte[] body = jsonResponse.getBytes(StandardCharsets.UTF_8);
+    InputStream inputStream = new ByteArrayInputStream(body);
+    HttpResponse httpResponse = new BasicHttpResponse(new BasicStatusLine(HttpVersion.HTTP_1_1, 200,
+      "OK"));
+    httpResponse.setEntity(new InputStreamEntity(inputStream, body.length));
+    RestAPIResponse mockResponse = new RestAPIResponse(Collections.emptyMap(), httpResponse, null);
     Mockito.doReturn(mockResponse).when(implSpy).executeGetWithRetries(Mockito.any());
     Schema schema = implSpy.fetchTableSchema("sys_user", "dummy-access-token",
       SourceValueType.SHOW_ACTUAL_VALUE, SchemaType.SCHEMA_API_BASED, false);
@@ -133,7 +147,12 @@ public class ServiceNowTableAPIClientImplTest {
       "  }\n" +
       "}";
 
-    RestAPIResponse mockResponse = new RestAPIResponse(Collections.emptyMap(), jsonResponse, null);
+    byte[] body = jsonResponse.getBytes(StandardCharsets.UTF_8);
+    InputStream inputStream = new ByteArrayInputStream(body);
+    HttpResponse httpResponse = new BasicHttpResponse(new BasicStatusLine(HttpVersion.HTTP_1_1, 200,
+      "OK"));
+    httpResponse.setEntity(new InputStreamEntity(inputStream, body.length));
+    RestAPIResponse mockResponse = new RestAPIResponse(Collections.emptyMap(), httpResponse, null);
     Mockito.doReturn(mockResponse).when(implSpy).executeGetWithRetries(Mockito.any());
 
     Schema schema = implSpy.fetchTableSchema("u_custom_table",
@@ -172,7 +191,12 @@ public class ServiceNowTableAPIClientImplTest {
       "    }\n" +
       "  ]\n" +
       "}";
-    RestAPIResponse mockResponse = new RestAPIResponse(Collections.emptyMap(), jsonResponse, null);
+    byte[] body = jsonResponse.getBytes(StandardCharsets.UTF_8);
+    InputStream inputStream = new ByteArrayInputStream(body);
+    HttpResponse httpResponse = new BasicHttpResponse(new BasicStatusLine(HttpVersion.HTTP_1_1, 200,
+      "OK"));
+    httpResponse.setEntity(new InputStreamEntity(inputStream, body.length));
+    RestAPIResponse mockResponse = new RestAPIResponse(Collections.emptyMap(), httpResponse, null);
     Mockito.doReturn(mockResponse).when(implSpy).executeGetWithRetries(Mockito.any());
     Schema schema = implSpy.fetchTableSchema("sys_user", "dummy-access-token",
       SourceValueType.SHOW_DISPLAY_VALUE, SchemaType.SCHEMA_API_BASED, false);
@@ -209,7 +233,12 @@ public class ServiceNowTableAPIClientImplTest {
       "    }\n" +
       "  }\n" +
       "}";
-    RestAPIResponse mockResponse = new RestAPIResponse(Collections.emptyMap(), jsonResponse, null);
+    byte[] body = jsonResponse.getBytes(StandardCharsets.UTF_8);
+    InputStream inputStream = new ByteArrayInputStream(body);
+    HttpResponse httpResponse = new BasicHttpResponse(new BasicStatusLine(HttpVersion.HTTP_1_1, 200,
+      "OK"));
+    httpResponse.setEntity(new InputStreamEntity(inputStream, body.length));
+    RestAPIResponse mockResponse = new RestAPIResponse(Collections.emptyMap(), httpResponse, null);
     Mockito.doReturn(mockResponse).when(implSpy).executeGetWithRetries(Mockito.any());
     Schema schema = implSpy.fetchTableSchema("incident", "dummy-access-token",
       SourceValueType.SHOW_DISPLAY_VALUE, SchemaType.METADATA_API_BASED, false);
@@ -247,7 +276,13 @@ public class ServiceNowTableAPIClientImplTest {
       "    }\n" +
       "  }\n" +
       "}";
-    RestAPIResponse mockResponse = new RestAPIResponse(Collections.emptyMap(), jsonResponse, null);
+    byte[] body = jsonResponse.getBytes(StandardCharsets.UTF_8);
+    InputStream inputStream = new ByteArrayInputStream(body);
+    HttpResponse httpResponse = new BasicHttpResponse(new BasicStatusLine(HttpVersion.HTTP_1_1, 200,
+      "OK"));
+    httpResponse.setEntity(new InputStreamEntity(inputStream, body.length));
+
+    RestAPIResponse mockResponse = new RestAPIResponse(Collections.emptyMap(), httpResponse, null);
     Mockito.doReturn(mockResponse).when(implSpy).executeGetWithRetries(Mockito.any());
     Schema schema = implSpy.fetchTableSchema("u_custom_13", "dummy-access-token",
       SourceValueType.SHOW_ACTUAL_VALUE, SchemaType.METADATA_API_BASED, false);
@@ -285,7 +320,12 @@ public class ServiceNowTableAPIClientImplTest {
       "    }\n" +
       "  }\n" +
       "}";
-    RestAPIResponse mockResponse = new RestAPIResponse(Collections.emptyMap(), jsonResponse, null);
+    byte[] body = jsonResponse.getBytes(StandardCharsets.UTF_8);
+    InputStream inputStream = new ByteArrayInputStream(body);
+    HttpResponse httpResponse = new BasicHttpResponse(new BasicStatusLine(HttpVersion.HTTP_1_1, 200,
+      "OK"));
+    httpResponse.setEntity(new InputStreamEntity(inputStream, body.length));
+    RestAPIResponse mockResponse = new RestAPIResponse(Collections.emptyMap(), httpResponse, null);
     Mockito.doReturn(mockResponse).when(implSpy).executeGetWithRetries(Mockito.any());
     Schema schema = implSpy.fetchTableSchema("u_custom_13", "dummy-access-token",
      SourceValueType.SHOW_ACTUAL_VALUE, SchemaType.METADATA_API_BASED, true);
@@ -323,7 +363,12 @@ public class ServiceNowTableAPIClientImplTest {
       "    }\n" +
       "  }\n" +
       "}";
-    RestAPIResponse mockResponse = new RestAPIResponse(Collections.emptyMap(), jsonResponse, null);
+    byte[] body = jsonResponse.getBytes(StandardCharsets.UTF_8);
+    InputStream inputStream = new ByteArrayInputStream(body);
+    HttpResponse httpResponse = new BasicHttpResponse(new BasicStatusLine(HttpVersion.HTTP_1_1, 200,
+      "OK"));
+    httpResponse.setEntity(new InputStreamEntity(inputStream, body.length));
+    RestAPIResponse mockResponse = new RestAPIResponse(Collections.emptyMap(), httpResponse, null);
     Mockito.doReturn(mockResponse).when(implSpy).executeGetWithRetries(Mockito.any());
     Schema schema = implSpy.fetchTableSchema("u_custom_13", "dummy-access-token",
       SourceValueType.SHOW_DISPLAY_VALUE, SchemaType.METADATA_API_BASED, false);
@@ -361,7 +406,12 @@ public class ServiceNowTableAPIClientImplTest {
       "    }\n" +
       "  }\n" +
       "}";
-    RestAPIResponse mockResponse = new RestAPIResponse(Collections.emptyMap(), jsonResponse, null);
+    byte[] body = jsonResponse.getBytes(StandardCharsets.UTF_8);
+    InputStream inputStream = new ByteArrayInputStream(body);
+    HttpResponse httpResponse = new BasicHttpResponse(new BasicStatusLine(HttpVersion.HTTP_1_1, 200,
+      "OK"));
+    httpResponse.setEntity(new InputStreamEntity(inputStream, body.length));
+    RestAPIResponse mockResponse = new RestAPIResponse(Collections.emptyMap(), httpResponse, null);
     Mockito.doReturn(mockResponse).when(implSpy).executeGetWithRetries(Mockito.any());
     Schema schema = implSpy.fetchTableSchema("u_custom_13", "dummy-access-token",
       SourceValueType.SHOW_DISPLAY_VALUE, SchemaType.METADATA_API_BASED, true);

--- a/src/test/java/io/cdap/plugin/servicenow/connector/ServiceNowConnectorTest.java
+++ b/src/test/java/io/cdap/plugin/servicenow/connector/ServiceNowConnectorTest.java
@@ -15,6 +15,7 @@
  */
 package io.cdap.plugin.servicenow.connector;
 
+import com.google.gson.JsonObject;
 import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.etl.api.batch.BatchSource;
 import io.cdap.cdap.etl.api.connector.ConnectorContext;
@@ -26,6 +27,7 @@ import io.cdap.cdap.etl.mock.common.MockConnectorContext;
 import io.cdap.cdap.etl.mock.validation.MockFailureCollector;
 import io.cdap.plugin.common.ConfigUtil;
 import io.cdap.plugin.servicenow.apiclient.ServiceNowTableAPIClientImpl;
+import io.cdap.plugin.servicenow.restapi.RestAPIClient;
 import io.cdap.plugin.servicenow.restapi.RestAPIResponse;
 import io.cdap.plugin.servicenow.source.ServiceNowBaseSourceConfig;
 import io.cdap.plugin.servicenow.source.ServiceNowInputFormat;
@@ -36,12 +38,16 @@ import io.cdap.plugin.servicenow.util.ServiceNowConstants;
 import io.cdap.plugin.servicenow.util.ServiceNowTableInfo;
 import io.cdap.plugin.servicenow.util.SourceQueryMode;
 import io.cdap.plugin.servicenow.util.SourceValueType;
+import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
+import org.apache.http.HttpVersion;
 import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.entity.InputStreamEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.message.BasicHttpResponse;
+import org.apache.http.message.BasicStatusLine;
 import org.apache.oltu.oauth2.client.OAuthClient;
-import org.apache.oltu.oauth2.client.URLConnectionClient;
 import org.apache.oltu.oauth2.client.response.OAuthJSONAccessTokenResponse;
 import org.junit.Assert;
 import org.junit.Before;
@@ -53,7 +59,10 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -95,6 +104,9 @@ public class ServiceNowConnectorTest {
   public void testTest() throws Exception {
     MockFailureCollector collector = new MockFailureCollector();
     ConnectorContext context = new MockConnectorContext(new MockConnectorConfigurer());
+    CloseableHttpClient mockHttpClient = Mockito.mock(CloseableHttpClient.class);
+    PowerMockito.stub(PowerMockito.method(RestAPIClient.class, "getHttpClient"))
+      .toReturn(mockHttpClient);
     ServiceNowTableAPIClientImpl restApi = Mockito.mock(ServiceNowTableAPIClientImpl.class);
     Mockito.when(restApi.getAccessToken()).thenReturn("token");
     PowerMockito.whenNew(ServiceNowTableAPIClientImpl.class).withAnyArguments().thenReturn(restApi);
@@ -106,6 +118,9 @@ public class ServiceNowConnectorTest {
   @Test
   public void testTestWithInvalidToken() throws Exception {
     ConnectorContext context = new MockConnectorContext(new MockConnectorConfigurer());
+    CloseableHttpClient mockHttpClient = Mockito.mock(CloseableHttpClient.class);
+    PowerMockito.stub(PowerMockito.method(RestAPIClient.class, "getHttpClient"))
+      .toReturn(mockHttpClient);
     ServiceNowConnector serviceNowConnector = new ServiceNowConnector(serviceNowSourceConfig.getConnection());
     serviceNowConnector.test(context);
     Assert.assertEquals(1, context.getFailureCollector().getValidationFailures().size());
@@ -116,10 +131,10 @@ public class ServiceNowConnectorTest {
     ServiceNowTableAPIClientImpl restApi = Mockito.mock(ServiceNowTableAPIClientImpl.class);
     Mockito.when(restApi.getAccessToken()).thenReturn("token");
     PowerMockito.whenNew(ServiceNowTableAPIClientImpl.class).withAnyArguments().thenReturn(restApi);
-    Map<String, String> map = new HashMap<>();
-    List<Map<String, String>> result = new ArrayList<>();
-    map.put("key", "value");
-    result.add(map);
+    JsonObject jsonObject = new JsonObject();
+    List<JsonObject> result = new ArrayList<>();
+    jsonObject.addProperty("key", "value");
+    result.add(jsonObject);
     int httpStatus = HttpStatus.SC_OK;
     Map<String, String> headers = new HashMap<>();
     String responseBody = "{\n" +
@@ -131,9 +146,13 @@ public class ServiceNowConnectorTest {
       "        }\n" +
       "    ]\n" +
       "}";
-    RestAPIResponse restAPIResponse = new RestAPIResponse(headers, responseBody, null);
+    byte[] body = responseBody.getBytes(StandardCharsets.UTF_8);
+    InputStream inputStream = new ByteArrayInputStream(body);
+    HttpResponse httpResponse = new BasicHttpResponse(new BasicStatusLine(HttpVersion.HTTP_1_1, 200,
+      "OK"));
+    httpResponse.setEntity(new InputStreamEntity(inputStream, body.length));
+    RestAPIResponse restAPIResponse = new RestAPIResponse(headers, httpResponse, null);
     Mockito.when(restApi.executeGetWithRetries(Mockito.any())).thenReturn(restAPIResponse);
-    Mockito.when(restApi.parseResponseToResultListOfMap(restAPIResponse.getResponseBody())).thenReturn(result);
     OAuthClient oAuthClient = Mockito.mock(OAuthClient.class);
     PowerMockito.whenNew(ServiceNowTableAPIClientImpl.class).withAnyArguments().thenReturn(restApi);
     OAuthJSONAccessTokenResponse accessTokenResponse = Mockito.mock(OAuthJSONAccessTokenResponse.class);
@@ -147,8 +166,8 @@ public class ServiceNowConnectorTest {
     PowerMockito.mockStatic(RestAPIResponse.class);
     PowerMockito.when(HttpClientBuilder.create()).thenReturn(httpClientBuilder);
     Mockito.when(httpClientBuilder.build()).thenReturn(httpClient);
-    CloseableHttpResponse httpResponse = Mockito.mock(CloseableHttpResponse.class);
-    Mockito.when(httpClient.execute(Mockito.any())).thenReturn(httpResponse);
+    CloseableHttpResponse closeableHttpResponse = Mockito.mock(CloseableHttpResponse.class);
+    Mockito.when(httpClient.execute(Mockito.any())).thenReturn(closeableHttpResponse);
     PowerMockito.when(RestAPIResponse.parse(ArgumentMatchers.any(), ArgumentMatchers.anyString())).
       thenReturn(response);
     ServiceNowConnector serviceNowConnector = new ServiceNowConnector(serviceNowSourceConfig.getConnection());

--- a/src/test/java/io/cdap/plugin/servicenow/restapi/RestAPIClientTest.java
+++ b/src/test/java/io/cdap/plugin/servicenow/restapi/RestAPIClientTest.java
@@ -40,16 +40,14 @@ public class RestAPIClientTest {
     Mockito.when(httpResponse.getStatusLine()).thenReturn(statusLine);
 
     CloseableHttpClient httpClient = Mockito.mock(CloseableHttpClient.class);
-    HttpClientBuilder httpClientBuilder = Mockito.mock(HttpClientBuilder.class);
-    PowerMockito.mockStatic(HttpClientBuilder.class);
-    PowerMockito.when(HttpClientBuilder.create()).thenReturn(httpClientBuilder);
-    Mockito.when(httpClientBuilder.build()).thenReturn(httpClient);
     Mockito.when(httpClient.execute(Mockito.any())).thenReturn(httpResponse);
 
     ServiceNowTableAPIRequestBuilder builder = new ServiceNowTableAPIRequestBuilder("url");
     RestAPIRequest request = builder.build();
 
     ServiceNowConnectorConfig config = Mockito.mock(ServiceNowConnectorConfig.class);
+    PowerMockito.stub(PowerMockito.method(RestAPIClient.class, "getHttpClient"))
+      .toReturn(httpClient);
     ServiceNowTableAPIClientImpl client = new ServiceNowTableAPIClientImpl(config, true);
     RestAPIResponse actualResponse = client.executeGet(request);
     Assert.assertNotNull(actualResponse.getException());
@@ -64,16 +62,14 @@ public class RestAPIClientTest {
     Mockito.when(httpResponse.getStatusLine()).thenReturn(statusLine);
 
     CloseableHttpClient httpClient = Mockito.mock(CloseableHttpClient.class);
-    HttpClientBuilder httpClientBuilder = Mockito.mock(HttpClientBuilder.class);
-    PowerMockito.mockStatic(HttpClientBuilder.class);
-    PowerMockito.when(HttpClientBuilder.create()).thenReturn(httpClientBuilder);
-    Mockito.when(httpClientBuilder.build()).thenReturn(httpClient);
     Mockito.when(httpClient.execute(Mockito.any())).thenReturn(httpResponse);
 
     ServiceNowTableAPIRequestBuilder builder = new ServiceNowTableAPIRequestBuilder("url");
     RestAPIRequest request = builder.build();
 
     ServiceNowConnectorConfig config = Mockito.mock(ServiceNowConnectorConfig.class);
+    PowerMockito.stub(PowerMockito.method(RestAPIClient.class, "getHttpClient"))
+      .toReturn(httpClient);
     ServiceNowTableAPIClientImpl client = new ServiceNowTableAPIClientImpl(config, true);
     RestAPIResponse actualResponse = client.executeGet(request);
     Assert.assertNotNull(actualResponse.getException());
@@ -108,10 +104,6 @@ public class RestAPIClientTest {
   @Test
   public void testExecuteGet_throwConnectTimeoutException_markAsRetryable() throws IOException {
     CloseableHttpClient httpClient = Mockito.mock(CloseableHttpClient.class);
-    HttpClientBuilder httpClientBuilder = Mockito.mock(HttpClientBuilder.class);
-    PowerMockito.mockStatic(HttpClientBuilder.class);
-    PowerMockito.when(HttpClientBuilder.create()).thenReturn(httpClientBuilder);
-    Mockito.when(httpClientBuilder.build()).thenReturn(httpClient);
     Mockito.when(httpClient.execute(Mockito.any()))
       .thenThrow(new ConnectTimeoutException("Connection timed out"));
 
@@ -119,6 +111,8 @@ public class RestAPIClientTest {
     RestAPIRequest request = builder.build();
 
     ServiceNowConnectorConfig config = Mockito.mock(ServiceNowConnectorConfig.class);
+    PowerMockito.stub(PowerMockito.method(RestAPIClient.class, "getHttpClient"))
+      .toReturn(httpClient);
     ServiceNowTableAPIClientImpl client = new ServiceNowTableAPIClientImpl(config, true);
     RestAPIResponse actualResponse = client.executeGet(request);
     Assert.assertNotNull(actualResponse.getException());
@@ -131,10 +125,6 @@ public class RestAPIClientTest {
   @Test
   public void testExecuteGet_throwSocketException_markAsRetryable() throws IOException {
     CloseableHttpClient httpClient = Mockito.mock(CloseableHttpClient.class);
-    HttpClientBuilder httpClientBuilder = Mockito.mock(HttpClientBuilder.class);
-    PowerMockito.mockStatic(HttpClientBuilder.class);
-    PowerMockito.when(HttpClientBuilder.create()).thenReturn(httpClientBuilder);
-    Mockito.when(httpClientBuilder.build()).thenReturn(httpClient);
     Mockito.when(httpClient.execute(Mockito.any()))
       .thenThrow(new SocketException());
 
@@ -142,6 +132,8 @@ public class RestAPIClientTest {
     RestAPIRequest request = builder.build();
 
     ServiceNowConnectorConfig config = Mockito.mock(ServiceNowConnectorConfig.class);
+    PowerMockito.stub(PowerMockito.method(RestAPIClient.class, "getHttpClient"))
+      .toReturn(httpClient);
     ServiceNowTableAPIClientImpl client = new ServiceNowTableAPIClientImpl(config, true);
     RestAPIResponse actualResponse = client.executeGet(request);
     Assert.assertNotNull(actualResponse.getException());

--- a/src/test/java/io/cdap/plugin/servicenow/sink/ServiceNowRecordWriterTest.java
+++ b/src/test/java/io/cdap/plugin/servicenow/sink/ServiceNowRecordWriterTest.java
@@ -16,18 +16,13 @@
 package io.cdap.plugin.servicenow.sink;
 
 import com.google.gson.JsonObject;
-import io.cdap.plugin.servicenow.ServiceNowBaseConfig;
-import io.cdap.plugin.servicenow.apiclient.ServiceNowAPIException;
 import io.cdap.plugin.servicenow.apiclient.ServiceNowTableAPIClientImpl;
-import io.cdap.plugin.servicenow.connector.ServiceNowConnectorConfig;
 import io.cdap.plugin.servicenow.restapi.RestAPIClient;
 import io.cdap.plugin.servicenow.restapi.RestAPIRequest;
 import io.cdap.plugin.servicenow.restapi.RestAPIResponse;
 import io.cdap.plugin.servicenow.sink.service.ServiceNowSinkAPIRequestImpl;
 import io.cdap.plugin.servicenow.sink.transform.ServiceNowRecordWriter;
 import io.cdap.plugin.servicenow.source.ServiceNowBaseSourceConfig;
-import org.apache.hadoop.mapreduce.TaskAttemptContext;
-import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
@@ -93,15 +88,14 @@ public class ServiceNowRecordWriterTest {
     ServiceNowTableAPIClientImpl restApi = Mockito.mock(ServiceNowTableAPIClientImpl.class);
     Mockito.when(restApi.getAccessToken()).thenReturn("token");
     PowerMockito.whenNew(ServiceNowTableAPIClientImpl.class).withAnyArguments().thenReturn(restApi);
-    Map<String, String> map = new HashMap<>();
-    List<Map<String, String>> result = new ArrayList<>();
-    map.put("key", "value");
-    result.add(map);
+    JsonObject jsonObject1 = new JsonObject();
+    List<JsonObject> result = new ArrayList<>();
+    jsonObject1.addProperty("key", "value");
+    result.add(jsonObject);
     Map<String, String> headers = new HashMap<>();
     RestAPIResponse restAPIResponse = new RestAPIResponse(
-        headers, responseBody, null);
+        headers, null, null);
     Mockito.when(restApi.executePost(Mockito.any())).thenReturn(restAPIResponse);
-    Mockito.when(restApi.parseResponseToResultListOfMap(restAPIResponse.getResponseBody())).thenReturn(result);
     OAuthClient oAuthClient = Mockito.mock(OAuthClient.class);
     PowerMockito.whenNew(ServiceNowTableAPIClientImpl.class).withAnyArguments().thenReturn(restApi);
     OAuthJSONAccessTokenResponse accessTokenResponse = Mockito.mock(OAuthJSONAccessTokenResponse.class);
@@ -138,14 +132,13 @@ public class ServiceNowRecordWriterTest {
     ServiceNowSinkAPIRequestImpl serviceNowSinkAPIRequest = Mockito.mock(ServiceNowSinkAPIRequestImpl.class);
     PowerMockito.whenNew(ServiceNowSinkAPIRequestImpl.class).withParameterTypes(ServiceNowSinkConfig.class)
       .withArguments(Mockito.any(ServiceNowSinkConfig.class)).thenReturn(serviceNowSinkAPIRequest);
-    Map<String, String> map = new HashMap<>();
-    List<Map<String, String>> result = new ArrayList<>();
-    map.put("key", "value");
-    result.add(map);
+    JsonObject jsonObject1 = new JsonObject();
+    List<JsonObject> result = new ArrayList<>();
+    jsonObject1.addProperty("key", "value");
+    result.add(jsonObject);
     Map<String, String> headers = new HashMap<>();
-    RestAPIResponse restAPIResponse = new RestAPIResponse(headers, responseBody, null);
+    RestAPIResponse restAPIResponse = new RestAPIResponse(headers, null, null);
     Mockito.when(restApi.executePost(Mockito.any(RestAPIRequest.class))).thenReturn(restAPIResponse);
-    Mockito.when(restApi.parseResponseToResultListOfMap(restAPIResponse.getResponseBody())).thenReturn(result);
     OAuthClient oAuthClient = Mockito.mock(OAuthClient.class);
     PowerMockito.whenNew(OAuthClient.class).
       withArguments(Mockito.any(URLConnectionClient.class)).thenReturn(oAuthClient);
@@ -186,14 +179,13 @@ public class ServiceNowRecordWriterTest {
     ServiceNowSinkAPIRequestImpl serviceNowSinkAPIRequest = Mockito.mock(ServiceNowSinkAPIRequestImpl.class);
     PowerMockito.whenNew(ServiceNowSinkAPIRequestImpl.class).withParameterTypes(ServiceNowSinkConfig.class)
       .withArguments(Mockito.any(ServiceNowSinkConfig.class)).thenReturn(serviceNowSinkAPIRequest);
-    Map<String, String> map = new HashMap<>();
-    List<Map<String, String>> result = new ArrayList<>();
-    map.put("key", "value");
-    result.add(map);
+    JsonObject jsonObject1 = new JsonObject();
+    List<JsonObject> result = new ArrayList<>();
+    jsonObject1.addProperty("key", "value");
+    result.add(jsonObject);
     Map<String, String> headers = new HashMap<>();
-    RestAPIResponse restAPIResponse = new RestAPIResponse(headers, responseBody, null);
+    RestAPIResponse restAPIResponse = new RestAPIResponse(headers, null, null);
     Mockito.when(restApi.executePost(Mockito.any(RestAPIRequest.class))).thenReturn(restAPIResponse);
-    Mockito.when(restApi.parseResponseToResultListOfMap(restAPIResponse.getResponseBody())).thenReturn(result);
     OAuthClient oAuthClient = Mockito.mock(OAuthClient.class);
     PowerMockito.whenNew(OAuthClient.class).
       withArguments(Mockito.any(URLConnectionClient.class)).thenReturn(oAuthClient);

--- a/src/test/java/io/cdap/plugin/servicenow/sink/ServiceNowSinkConfigTest.java
+++ b/src/test/java/io/cdap/plugin/servicenow/sink/ServiceNowSinkConfigTest.java
@@ -32,10 +32,13 @@ import io.cdap.plugin.servicenow.restapi.RestAPIResponse;
 import io.cdap.plugin.servicenow.util.ServiceNowConstants;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
+import org.apache.http.HttpVersion;
 import org.apache.http.StatusLine;
 import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.entity.InputStreamEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.message.BasicHttpResponse;
 import org.apache.http.message.BasicStatusLine;
 import org.apache.oltu.oauth2.client.OAuthClient;
 import org.apache.oltu.oauth2.client.URLConnectionClient;
@@ -50,6 +53,9 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -296,6 +302,11 @@ public class ServiceNowSinkConfigTest {
       "        }\n" +
       "    ]\n" +
       "}";
+    byte[] body = responseBody.getBytes(StandardCharsets.UTF_8);
+    InputStream inputStream = new ByteArrayInputStream(body);
+    HttpResponse httpResponse = new BasicHttpResponse(new BasicStatusLine(HttpVersion.HTTP_1_1, 200,
+      "OK"));
+    httpResponse.setEntity(new InputStreamEntity(inputStream, body.length));
     MetadataAPISchemaField schemaField = new MetadataAPISchemaField("Class", "sys_class_name",
       "sys_class_name", "sys_class_name");
     Map<String, MetadataAPISchemaField> columns = new HashMap<>();
@@ -306,7 +317,7 @@ public class ServiceNowSinkConfigTest {
     Mockito.when(mockResponse.getStatusLine()).thenReturn(Mockito.mock(StatusLine.class));
     Mockito.when(mockResponse.getStatusLine().getStatusCode()).thenReturn(httpStatus);
     RestAPIResponse restAPIResponse = new RestAPIResponse(
-        headers, responseBody, new ServiceNowAPIException("", mockResponse));
+        headers, httpResponse, new ServiceNowAPIException("", mockResponse));
     OAuthClient oAuthClient = Mockito.mock(OAuthClient.class);
     PowerMockito.whenNew(OAuthClient.class).
       withArguments(Mockito.any(URLConnectionClient.class)).thenReturn(oAuthClient);
@@ -321,12 +332,12 @@ public class ServiceNowSinkConfigTest {
     PowerMockito.mockStatic(RestAPIResponse.class);
     PowerMockito.when(HttpClientBuilder.create()).thenReturn(httpClientBuilder);
     Mockito.when(httpClientBuilder.build()).thenReturn(httpClient);
-    CloseableHttpResponse httpResponse = Mockito.mock(CloseableHttpResponse.class);
-    Mockito.when(httpClient.execute(Mockito.any())).thenReturn(httpResponse);
-    PowerMockito.when(RestAPIResponse.parse(httpResponse, null)).thenReturn(response);
+    CloseableHttpResponse closeableHttpResponse = Mockito.mock(CloseableHttpResponse.class);
+    Mockito.when(httpClient.execute(Mockito.any())).thenReturn(closeableHttpResponse);
+    PowerMockito.when(RestAPIResponse.parse(closeableHttpResponse, null)).thenReturn(response);
     Mockito.when(restApi.executeGetWithRetries(Mockito.any(RestAPIRequest.class))).thenReturn(restAPIResponse);
     Mockito.when(restApi.fetchTableSchema(Mockito.anyString(), Mockito.any(FailureCollector.class))).thenReturn(schema);
-    Mockito.when(restApi.parseSchemaResponse(restAPIResponse.getResponseBody()))
+    Mockito.when(restApi.parseSchemaResponse(restAPIResponse.getResponseStream()))
       .thenReturn(metadataAPISchemaResponse);
     try {
       config.validateSchema(schema, collector);
@@ -362,7 +373,12 @@ public class ServiceNowSinkConfigTest {
       "    }\n" +
       "  ]\n" +
       "}";
-    RestAPIResponse restAPIResponse = new RestAPIResponse(headers, responseBody, null);
+    byte[] body = responseBody.getBytes(StandardCharsets.UTF_8);
+    InputStream inputStream = new ByteArrayInputStream(body);
+    HttpResponse httpResponse = new BasicHttpResponse(new BasicStatusLine(HttpVersion.HTTP_1_1, 200,
+      "OK"));
+    httpResponse.setEntity(new InputStreamEntity(inputStream, body.length));
+    RestAPIResponse restAPIResponse = new RestAPIResponse(headers, httpResponse, null);
     OAuthClient oAuthClient = Mockito.mock(OAuthClient.class);
     PowerMockito.whenNew(OAuthClient.class).
       withArguments(Mockito.any(URLConnectionClient.class)).thenReturn(oAuthClient);
@@ -377,12 +393,12 @@ public class ServiceNowSinkConfigTest {
     PowerMockito.mockStatic(RestAPIResponse.class);
     PowerMockito.when(HttpClientBuilder.create()).thenReturn(httpClientBuilder);
     Mockito.when(httpClientBuilder.build()).thenReturn(httpClient);
-    CloseableHttpResponse httpResponse = Mockito.mock(CloseableHttpResponse.class);
+    CloseableHttpResponse closeableHttpResponse = Mockito.mock(CloseableHttpResponse.class);
     StatusLine statusLine = Mockito.mock(BasicStatusLine.class);
     Mockito.when(statusLine.getStatusCode()).thenReturn(HttpStatus.SC_OK);
-    Mockito.when(httpResponse.getStatusLine()).thenReturn(statusLine);
-    Mockito.when(httpClient.execute(Mockito.any())).thenReturn(httpResponse);
-    PowerMockito.when(RestAPIResponse.parse(httpResponse, null)).thenReturn(response);
+    Mockito.when(closeableHttpResponse.getStatusLine()).thenReturn(statusLine);
+    Mockito.when(httpClient.execute(Mockito.any())).thenReturn(closeableHttpResponse);
+    PowerMockito.when(RestAPIResponse.parse(closeableHttpResponse, null)).thenReturn(response);
     Mockito.when(restApi.executeGetWithRetries(Mockito.any(RestAPIRequest.class))).thenReturn(restAPIResponse);
     Mockito.when(restApi.fetchTableSchema("tableName", collector)).
       thenReturn(schema);

--- a/src/test/java/io/cdap/plugin/servicenow/sink/ServiceNowSinkTest.java
+++ b/src/test/java/io/cdap/plugin/servicenow/sink/ServiceNowSinkTest.java
@@ -25,17 +25,19 @@ import io.cdap.cdap.etl.api.batch.BatchSinkContext;
 import io.cdap.cdap.etl.mock.common.MockArguments;
 import io.cdap.cdap.etl.mock.common.MockPipelineConfigurer;
 import io.cdap.cdap.etl.mock.validation.MockFailureCollector;
-import io.cdap.plugin.servicenow.ServiceNowBaseConfig;
 import io.cdap.plugin.servicenow.apiclient.ServiceNowTableAPIClientImpl;
-import io.cdap.plugin.servicenow.connector.ServiceNowConnectorConfig;
 import io.cdap.plugin.servicenow.restapi.RestAPIResponse;
 import io.cdap.plugin.servicenow.sink.transform.ServiceNowTransformer;
 import io.cdap.plugin.servicenow.source.ServiceNowBaseSourceConfig;
 import org.apache.hadoop.io.NullWritable;
-import org.apache.http.HttpStatus;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpVersion;
 import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.entity.InputStreamEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.message.BasicHttpResponse;
+import org.apache.http.message.BasicStatusLine;
 import org.apache.oltu.oauth2.client.OAuthClient;
 import org.apache.oltu.oauth2.client.URLConnectionClient;
 import org.apache.oltu.oauth2.client.response.OAuthJSONAccessTokenResponse;
@@ -48,6 +50,9 @@ import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -87,15 +92,19 @@ public class ServiceNowSinkTest {
     ServiceNowTableAPIClientImpl restApi = Mockito.mock(ServiceNowTableAPIClientImpl.class);
     Mockito.when(restApi.getAccessToken()).thenReturn("token");
     PowerMockito.whenNew(ServiceNowTableAPIClientImpl.class).withAnyArguments().thenReturn(restApi);
-    List<Map<String, String>> result = new ArrayList<>();
+    List<JsonObject> result = new ArrayList<>();
     Map<String, String> headers = new HashMap<>();
     String responseBody = "{\n" +
       "    \"result\": []\n" +
       "}";
+    byte[] body = responseBody.getBytes(StandardCharsets.UTF_8);
+    InputStream inputStream = new ByteArrayInputStream(body);
+    HttpResponse httpResponse = new BasicHttpResponse(new BasicStatusLine(HttpVersion.HTTP_1_1, 200,
+      "OK"));
+    httpResponse.setEntity(new InputStreamEntity(inputStream, body.length));
     MockFailureCollector collector = new MockFailureCollector();
-    RestAPIResponse restAPIResponse = new RestAPIResponse(headers, responseBody, null);
+    RestAPIResponse restAPIResponse = new RestAPIResponse(headers, httpResponse, null);
     Mockito.when(restApi.executeGetWithRetries(Mockito.any())).thenReturn(restAPIResponse);
-    Mockito.when(restApi.parseResponseToResultListOfMap(restAPIResponse.getResponseBody())).thenReturn(result);
     serviceNowSink.configurePipeline(mockPipelineConfigurer);
     Assert.assertNull(restAPIResponse.getException());
     Assert.assertEquals(0, collector.getValidationFailures().size());
@@ -110,10 +119,10 @@ public class ServiceNowSinkTest {
     Mockito.when(context.getArguments()).thenReturn(mockArguments);
     ServiceNowTableAPIClientImpl restApi = Mockito.mock(ServiceNowTableAPIClientImpl.class);
     PowerMockito.whenNew(ServiceNowTableAPIClientImpl.class).withAnyArguments().thenReturn(restApi);
-    List<Map<String, String>> result = new ArrayList<>();
-    Map<String, String> map = new HashMap<>();
-    map.put("key", "value");
-    result.add(map);
+    JsonObject jsonObject = new JsonObject();
+    List<JsonObject> result = new ArrayList<>();
+    jsonObject.addProperty("key", "value");
+    result.add(jsonObject);
     Map<String, String> headers = new HashMap<>();
     String responseBody = "{\n" +
       "    \"result\": [\n" +
@@ -125,14 +134,18 @@ public class ServiceNowSinkTest {
       "        }\n" +
       "    ]\n" +
       "}";
+    byte[] body = responseBody.getBytes(StandardCharsets.UTF_8);
+    InputStream inputStream = new ByteArrayInputStream(body);
+    HttpResponse httpResponse = new BasicHttpResponse(new BasicStatusLine(HttpVersion.HTTP_1_1, 200,
+      "OK"));
+    httpResponse.setEntity(new InputStreamEntity(inputStream, body.length));
     Schema schema = Schema.recordOf("record",
                                     Schema.Field.of("id", Schema.of(Schema.Type.LONG)),
                                     Schema.Field.of("price", Schema.of(Schema.Type.DOUBLE)));
     Emitter<KeyValue<NullWritable, JsonObject>> emitter = Mockito.mock(Emitter.class);
     Mockito.when(context.getInputSchema()).thenReturn(schema);
-    RestAPIResponse restAPIResponse = new RestAPIResponse(headers, responseBody, null);
+    RestAPIResponse restAPIResponse = new RestAPIResponse(headers, httpResponse, null);
     Mockito.when(restApi.executeGetWithRetries(Mockito.any())).thenReturn(restAPIResponse);
-    Mockito.when(restApi.parseResponseToResultListOfMap(restAPIResponse.getResponseBody())).thenReturn(result);
     OAuthClient oAuthClient = Mockito.mock(OAuthClient.class);
     PowerMockito.whenNew(OAuthClient.class).
       withArguments(Mockito.any(URLConnectionClient.class)).thenReturn(oAuthClient);
@@ -147,8 +160,8 @@ public class ServiceNowSinkTest {
     PowerMockito.mockStatic(RestAPIResponse.class);
     PowerMockito.when(HttpClientBuilder.create()).thenReturn(httpClientBuilder);
     Mockito.when(httpClientBuilder.build()).thenReturn(httpClient);
-    CloseableHttpResponse httpResponse = Mockito.mock(CloseableHttpResponse.class);
-    Mockito.when(httpClient.execute(Mockito.any())).thenReturn(httpResponse);
+    CloseableHttpResponse closeableHttpResponse = Mockito.mock(CloseableHttpResponse.class);
+    Mockito.when(httpClient.execute(Mockito.any())).thenReturn(closeableHttpResponse);
     PowerMockito.when(RestAPIResponse.parse(ArgumentMatchers.any(), ArgumentMatchers.anyString())).
       thenReturn(response);
     BatchRuntimeContext batchRuntimeContext = Mockito.mock(BatchRuntimeContext.class);

--- a/src/test/java/io/cdap/plugin/servicenow/source/ServiceNowInputFormatTest.java
+++ b/src/test/java/io/cdap/plugin/servicenow/source/ServiceNowInputFormatTest.java
@@ -17,6 +17,7 @@
 
 package io.cdap.plugin.servicenow.source;
 
+import com.google.gson.JsonObject;
 import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.plugin.servicenow.apiclient.ServiceNowTableAPIClientImpl;
 import io.cdap.plugin.servicenow.connector.ServiceNowConnectorConfig;
@@ -24,9 +25,14 @@ import io.cdap.plugin.servicenow.restapi.RestAPIResponse;
 import io.cdap.plugin.servicenow.util.SourceApplication;
 import io.cdap.plugin.servicenow.util.SourceQueryMode;
 import io.cdap.plugin.servicenow.util.SourceValueType;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpVersion;
 import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.entity.InputStreamEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.message.BasicHttpResponse;
+import org.apache.http.message.BasicStatusLine;
 import org.apache.oltu.oauth2.client.OAuthClient;
 import org.apache.oltu.oauth2.client.URLConnectionClient;
 import org.apache.oltu.oauth2.client.response.OAuthJSONAccessTokenResponse;
@@ -42,6 +48,9 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -71,10 +80,10 @@ public class ServiceNowInputFormatTest {
     SourceQueryMode mode = SourceQueryMode.TABLE;
     ServiceNowTableAPIClientImpl restApi = Mockito.mock(ServiceNowTableAPIClientImpl.class);
     PowerMockito.whenNew(ServiceNowTableAPIClientImpl.class).withAnyArguments().thenReturn(restApi);
-    List<Map<String, String>> result = new ArrayList<>();
-    Map<String, String> map = new HashMap<>();
-    map.put("key", "value");
-    result.add(map);
+    JsonObject jsonObject = new JsonObject();
+    List<JsonObject> result = new ArrayList<>();
+    jsonObject.addProperty("key", "value");
+    result.add(jsonObject);
     Map<String, String> headers = new HashMap<>();
     String responseBody = "{\n" +
       "    \"result\": [\n" +
@@ -138,13 +147,17 @@ public class ServiceNowInputFormatTest {
       "        }\n" +
       "    ]\n" +
       "}";
+    byte[] body = responseBody.getBytes(StandardCharsets.UTF_8);
+    InputStream inputStream = new ByteArrayInputStream(body);
+    HttpResponse httpResponse = new BasicHttpResponse(new BasicStatusLine(HttpVersion.HTTP_1_1, 200,
+      "OK"));
+    httpResponse.setEntity(new InputStreamEntity(inputStream, body.length));
     String schemaString = "{\"type\":\"record\",\"name\":\"ServiceNowColumnMetaData\",\"fields\":[{\"name\":" +
       "\"backgroundElementId\",\"type\":\"long\"},{\"name\":\"bgOrderPos\",\"type\":\"long\"},{\"name\":" +
       "\"description\",\"type\":[\"string\",\"null\"]},{\"name\":\"userId\",\"type\":\"string\"}]}";
     Schema schema = Schema.parseJson(schemaString);
-    RestAPIResponse restAPIResponse = new RestAPIResponse(headers, responseBody, null);
+    RestAPIResponse restAPIResponse = new RestAPIResponse(headers, httpResponse, null);
     Mockito.when(restApi.executeGetWithRetries(Mockito.any())).thenReturn(restAPIResponse);
-    Mockito.when(restApi.parseResponseToResultListOfMap(restAPIResponse.getResponseBody())).thenReturn(result);
     Mockito.when(restApi.fetchTableSchema("table", SourceValueType.SHOW_ACTUAL_VALUE)).thenReturn(schema);
     OAuthClient oAuthClient = Mockito.mock(OAuthClient.class);
     PowerMockito.whenNew(OAuthClient.class).
@@ -160,8 +173,8 @@ public class ServiceNowInputFormatTest {
     PowerMockito.mockStatic(RestAPIResponse.class);
     PowerMockito.when(HttpClientBuilder.create()).thenReturn(httpClientBuilder);
     Mockito.when(httpClientBuilder.build()).thenReturn(httpClient);
-    CloseableHttpResponse httpResponse = Mockito.mock(CloseableHttpResponse.class);
-    Mockito.when(httpClient.execute(Mockito.any())).thenReturn(httpResponse);
+    CloseableHttpResponse closeableHttpResponse = Mockito.mock(CloseableHttpResponse.class);
+    Mockito.when(httpClient.execute(Mockito.any())).thenReturn(closeableHttpResponse);
     PowerMockito.when(RestAPIResponse.parse(ArgumentMatchers.any(), ArgumentMatchers.anyString())).
       thenReturn(response);
     SourceApplication application = SourceApplication.PROCUREMENT;
@@ -175,10 +188,10 @@ public class ServiceNowInputFormatTest {
     SourceQueryMode mode = SourceQueryMode.REPORTING;
     ServiceNowTableAPIClientImpl restApi = Mockito.mock(ServiceNowTableAPIClientImpl.class);
     PowerMockito.whenNew(ServiceNowTableAPIClientImpl.class).withAnyArguments().thenReturn(restApi);
-    List<Map<String, String>> result = new ArrayList<>();
-    Map<String, String> map = new HashMap<>();
-    map.put("key", "value");
-    result.add(map);
+    JsonObject jsonObject = new JsonObject();
+    List<JsonObject> result = new ArrayList<>();
+    jsonObject.addProperty("key", "value");
+    result.add(jsonObject);
     Map<String, String> headers = new HashMap<>();
     String responseBody = "{\n" +
       "    \"result\": [\n" +
@@ -242,13 +255,17 @@ public class ServiceNowInputFormatTest {
       "        }\n" +
       "    ]\n" +
       "}";
+    byte[] body = responseBody.getBytes(StandardCharsets.UTF_8);
+    InputStream inputStream = new ByteArrayInputStream(body);
+    HttpResponse httpResponse = new BasicHttpResponse(new BasicStatusLine(HttpVersion.HTTP_1_1, 200,
+      "OK"));
+    httpResponse.setEntity(new InputStreamEntity(inputStream, body.length));
     String schemaString = "{\"type\":\"record\",\"name\":\"ServiceNowColumnMetaData\",\"fields\":[{\"name\":" +
       "\"backgroundElementId\",\"type\":\"long\"},{\"name\":\"bgOrderPos\",\"type\":\"long\"},{\"name\":" +
       "\"description\",\"type\":[\"string\",\"null\"]},{\"name\":\"userId\",\"type\":\"string\"}]}";
     Schema schema = Schema.parseJson(schemaString);
-    RestAPIResponse restAPIResponse = new RestAPIResponse(headers, responseBody, null);
+    RestAPIResponse restAPIResponse = new RestAPIResponse(headers, httpResponse, null);
     Mockito.when(restApi.executeGetWithRetries(Mockito.any())).thenReturn(restAPIResponse);
-    Mockito.when(restApi.parseResponseToResultListOfMap(restAPIResponse.getResponseBody())).thenReturn(result);
     Mockito.when(restApi.fetchTableSchema("proc_po", SourceValueType.SHOW_ACTUAL_VALUE)).thenReturn(schema);
     Mockito.when(restApi.fetchTableSchema("proc_po_item",
                                           SourceValueType.SHOW_ACTUAL_VALUE)).thenReturn(schema);
@@ -268,8 +285,8 @@ public class ServiceNowInputFormatTest {
     PowerMockito.mockStatic(RestAPIResponse.class);
     PowerMockito.when(HttpClientBuilder.create()).thenReturn(httpClientBuilder);
     Mockito.when(httpClientBuilder.build()).thenReturn(httpClient);
-    CloseableHttpResponse httpResponse = Mockito.mock(CloseableHttpResponse.class);
-    Mockito.when(httpClient.execute(Mockito.any())).thenReturn(httpResponse);
+    CloseableHttpResponse closeableHttpResponse = Mockito.mock(CloseableHttpResponse.class);
+    Mockito.when(httpClient.execute(Mockito.any())).thenReturn(closeableHttpResponse);
     PowerMockito.when(RestAPIResponse.parse(ArgumentMatchers.any(), ArgumentMatchers.anyString())).
       thenReturn(response);
     SourceApplication application = SourceApplication.PROCUREMENT;
@@ -283,17 +300,21 @@ public class ServiceNowInputFormatTest {
     SourceQueryMode mode = SourceQueryMode.TABLE;
     ServiceNowTableAPIClientImpl restApi = Mockito.mock(ServiceNowTableAPIClientImpl.class);
     PowerMockito.whenNew(ServiceNowTableAPIClientImpl.class).withAnyArguments().thenReturn(restApi);
-    List<Map<String, String>> result = new ArrayList<>();
-    Map<String, String> map = new HashMap<>();
-    map.put("key", "value");
-    result.add(map);
+    JsonObject jsonObject = new JsonObject();
+    List<JsonObject> result = new ArrayList<>();
+    jsonObject.addProperty("key", "value");
+    result.add(jsonObject);
     Map<String, String> headers = new HashMap<>();
     String responseBody = "{\n" +
       "    \"result\": []\n" +
       "}";
-    RestAPIResponse restAPIResponse = new RestAPIResponse(headers, responseBody, null);
+    byte[] body = responseBody.getBytes(StandardCharsets.UTF_8);
+    InputStream inputStream = new ByteArrayInputStream(body);
+    HttpResponse httpResponse = new BasicHttpResponse(new BasicStatusLine(HttpVersion.HTTP_1_1, 200,
+      "OK"));
+    httpResponse.setEntity(new InputStreamEntity(inputStream, body.length));
+    RestAPIResponse restAPIResponse = new RestAPIResponse(headers, httpResponse, null);
     Mockito.when(restApi.executeGetWithRetries(Mockito.any())).thenReturn(restAPIResponse);
-    Mockito.when(restApi.parseResponseToResultListOfMap(restAPIResponse.getResponseBody())).thenReturn(result);
     OAuthClient oAuthClient = Mockito.mock(OAuthClient.class);
     PowerMockito.mockStatic(ServiceNowInputFormat.class);
     PowerMockito.whenNew(OAuthClient.class).
@@ -309,8 +330,8 @@ public class ServiceNowInputFormatTest {
     PowerMockito.mockStatic(RestAPIResponse.class);
     PowerMockito.when(HttpClientBuilder.create()).thenReturn(httpClientBuilder);
     Mockito.when(httpClientBuilder.build()).thenReturn(httpClient);
-    CloseableHttpResponse httpResponse = Mockito.mock(CloseableHttpResponse.class);
-    Mockito.when(httpClient.execute(Mockito.any())).thenReturn(httpResponse);
+    CloseableHttpResponse closeableHttpResponse = Mockito.mock(CloseableHttpResponse.class);
+    Mockito.when(httpClient.execute(Mockito.any())).thenReturn(closeableHttpResponse);
     PowerMockito.when(RestAPIResponse.parse(ArgumentMatchers.any(), ArgumentMatchers.anyString())).
       thenReturn(response);
     SourceApplication application = SourceApplication.PROCUREMENT;

--- a/src/test/java/io/cdap/plugin/servicenow/source/ServiceNowMultiRecordReaderTest.java
+++ b/src/test/java/io/cdap/plugin/servicenow/source/ServiceNowMultiRecordReaderTest.java
@@ -16,6 +16,7 @@
 
 package io.cdap.plugin.servicenow.source;
 
+import com.google.gson.JsonObject;
 import io.cdap.cdap.api.data.format.StructuredRecord;
 import io.cdap.cdap.api.data.format.UnexpectedFormatException;
 import io.cdap.cdap.api.data.schema.Schema;
@@ -24,6 +25,14 @@ import io.cdap.plugin.servicenow.apiclient.ServiceNowAPIException;
 import io.cdap.plugin.servicenow.apiclient.ServiceNowTableAPIClientImpl;
 import io.cdap.plugin.servicenow.apiclient.ServiceNowTableDataResponse;
 import io.cdap.plugin.servicenow.connector.ServiceNowRecordConverter;
+import io.cdap.plugin.servicenow.restapi.RestAPIClient;
+import io.cdap.plugin.servicenow.restapi.RestAPIResponse;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpVersion;
+import org.apache.http.entity.InputStreamEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.message.BasicHttpResponse;
+import org.apache.http.message.BasicStatusLine;
 import org.apache.oltu.oauth2.common.exception.OAuthProblemException;
 import org.apache.oltu.oauth2.common.exception.OAuthSystemException;
 import org.junit.Assert;
@@ -31,9 +40,16 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
 import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -41,6 +57,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ServiceNowTableAPIClientImpl.class, ServiceNowMultiSourceConfig.class,
+  ServiceNowMultiRecordReader.class})
 public class ServiceNowMultiRecordReaderTest {
 
   private static final String CLIENT_ID = "clientId";
@@ -94,9 +113,9 @@ public class ServiceNowMultiRecordReaderTest {
     Schema fieldSchema = Schema.recordOf("record", Schema.Field.of("TimeField",
                                                                    Schema.of(Schema.LogicalType.TIMESTAMP_MILLIS)));
     StructuredRecord.Builder recordBuilder = StructuredRecord.builder(fieldSchema);
-    Map<String, String> map = new HashMap<>();
-    map.put("TimeField", "value");
-    ServiceNowRecordConverter.convertToValue("TimeField", fieldSchema, map, recordBuilder, false);
+    JsonObject record = new JsonObject();
+    record.addProperty("TimeField", "value");
+    ServiceNowRecordConverter.convertToValue("TimeField", fieldSchema, record, recordBuilder, false);
   }
 
   @Test
@@ -120,25 +139,64 @@ public class ServiceNowMultiRecordReaderTest {
   }
 
   @Test
-  public void testFetchData() throws ServiceNowAPIException, IOException {
+  public void testFetchData() throws Exception {
     String tableName = serviceNowMultiSourceConfig.getTableNames();
     ServiceNowInputSplit split = new ServiceNowInputSplit(tableName, 1, null);
-
-    List<Map<String, String>> results = new ArrayList<>();
-    Map<String, String> map = new HashMap<>();
-    map.put("calendar_integration", "1");
-    map.put("country", "India");
-    map.put("sys_updated_on", "2019-04-05 21:54:45");
-    map.put("web_service_access_only", "false");
-    map.put("notification", "2");
-    map.put("enable_multifactor_authn", "false");
-    map.put("sys_updated_by", "system");
-    map.put("sys_created_on", "2019-04-05 21:09:12");
-    results.add(map);
-
-    ServiceNowTableDataResponse response = new ServiceNowTableDataResponse();
-    response.setResult(results);
     ServiceNowTableAPIClientImpl restApi = Mockito.mock(ServiceNowTableAPIClientImpl.class);
+    ServiceNowMultiRecordReader serviceNowMultiRecordReader =
+      new ServiceNowMultiRecordReader(serviceNowMultiSourceConfig);
+    String responseBody = "{\n" +
+      "  \"result\": [\n" +
+      "    {\n" +
+      "      \"bill_to\": \"\",\n" +
+      "      \"init_request\": \"\",\n" +
+      "      \"short_description\": \"\",\n" +
+      "      \"total_cost\": \"0\",\n" +
+      "      \"due_by\": \"\",\n" +
+      "      \"description\": \"\",\n" +
+      "      \"requested_for\": \"\",\n" +
+      "      \"sys_updated_on\": \"2022-06-16 18:56:23\",\n" +
+      "      \"budget_number\": \"\",\n" +
+      "      \"number\": \"RCS397871\",\n" +
+      "      \"sys_id\": \"00000b7287405910827733373cbb35d5\",\n" +
+      "      \"sys_updated_by\": \"pipeline.user.1\",\n" +
+      "      \"shipping\": \"\",\n" +
+      "      \"terms\": \"\",\n" +
+      "      \"sys_created_on\": \"2022-06-16 18:56:23\",\n" +
+      "      \"vendor\": \"\",\n" +
+      "      \"sys_domain\": \"global\",\n" +
+      "      \"department\": \"\",\n" +
+      "      \"sys_created_by\": \"pipeline.user.1\",\n" +
+      "      \"assigned_to\": \"\",\n" +
+      "      \"ordered\": \"\",\n" +
+      "      \"po_date\": \"2022-06-16 18:56:23\",\n" +
+      "      \"vendor_contract\": \"\",\n" +
+      "      \"contract\": \"\",\n" +
+      "      \"expected_delivery\": \"\",\n" +
+      "      \"sys_mod_count\": \"0\",\n" +
+      "      \"received\": \"2158-05-10 17:14:20\",\n" +
+      "      \"asset_operation\": \"\",\n" +
+      "      \"sys_tags\": \"\",\n" +
+      "      \"requested\": \"2022-06-16 18:56:23\",\n" +
+      "      \"requested_by\": \"\",\n" +
+      "      \"ship_rate\": \"0\",\n" +
+      "      \"location\": \"\",\n" +
+      "      \"vendor_account\": \"\",\n" +
+      "      \"ship_to\": \"\",\n" +
+      "      \"status\": \"requested\"\n" +
+      "    }\n" +
+      "  ]\n" +
+      "}";
+    byte[] body = responseBody.getBytes(StandardCharsets.UTF_8);
+    InputStream inputStream = new ByteArrayInputStream(body);
+    HttpResponse httpResponse = new BasicHttpResponse(new BasicStatusLine(HttpVersion.HTTP_1_1, 200,
+      "OK"));
+    httpResponse.setEntity(new InputStreamEntity(inputStream, body.length));
+    RestAPIResponse restAPIResponse = new RestAPIResponse(Collections.emptyMap(), httpResponse, null);
+    PowerMockito.whenNew(ServiceNowTableAPIClientImpl.class).withAnyArguments().thenReturn(restApi);
+    Mockito.when(restApi.fetchTableRecordsRetryableMode(tableName, serviceNowMultiSourceConfig.getValueType(),
+      split.getFilterQuery(), split.getOffset(),
+        serviceNowMultiSourceConfig.getPageSize())).thenReturn(restAPIResponse);
     try {
       Mockito.when(restApi.fetchTableSchema(tableName, serviceNowMultiSourceConfig.getValueType()))
         .thenReturn(Schema.recordOf(Schema.Field.of("calendar_integration", Schema.of(Schema.Type.STRING))));
@@ -147,10 +205,6 @@ public class ServiceNowMultiRecordReaderTest {
              | ServiceNowAPIException e) {
       Assert.assertTrue(e instanceof RuntimeException);
     }
-    Mockito.doNothing().when(serviceNowMultiRecordReader).fetchData();
-    Collections.singletonList(new Object());
-    serviceNowMultiRecordReader.iterator = Collections.singletonList(Collections.singletonMap("key", new String())).
-      iterator();
     Assert.assertTrue(serviceNowMultiRecordReader.nextKeyValue());
   }
 
@@ -174,6 +228,9 @@ public class ServiceNowMultiRecordReaderTest {
             .setTableNameField("tablename")
             .buildMultiSource();
 
+    CloseableHttpClient mockHttpClient = Mockito.mock(CloseableHttpClient.class);
+    PowerMockito.stub(PowerMockito.method(RestAPIClient.class, "getHttpClient"))
+      .toReturn(mockHttpClient);
     String tableName = serviceNowMultiSourceConfig.getTableNames();
     ServiceNowTableAPIClientImpl restApi = Mockito.mock(ServiceNowTableAPIClientImpl.class);
     ServiceNowInputSplit split = new ServiceNowInputSplit(tableName, 1, null);

--- a/src/test/java/io/cdap/plugin/servicenow/source/ServiceNowMultiSourceConfigTest.java
+++ b/src/test/java/io/cdap/plugin/servicenow/source/ServiceNowMultiSourceConfigTest.java
@@ -16,11 +16,19 @@
 
 package io.cdap.plugin.servicenow.source;
 
+import com.google.gson.JsonObject;
 import io.cdap.cdap.etl.api.validation.ValidationException;
 import io.cdap.cdap.etl.api.validation.ValidationFailure;
 import io.cdap.cdap.etl.mock.validation.MockFailureCollector;
 import io.cdap.plugin.servicenow.apiclient.ServiceNowTableAPIClientImpl;
+import io.cdap.plugin.servicenow.restapi.RestAPIClient;
 import io.cdap.plugin.servicenow.restapi.RestAPIResponse;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpVersion;
+import org.apache.http.entity.InputStreamEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.message.BasicHttpResponse;
+import org.apache.http.message.BasicStatusLine;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -31,6 +39,9 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -77,6 +88,9 @@ public class ServiceNowMultiSourceConfigTest {
         .setEndDate("2021-12-31")
         .setTableNameField("tablename")
         .buildMultiSource();
+    CloseableHttpClient mockHttpClient = Mockito.mock(CloseableHttpClient.class);
+    PowerMockito.stub(PowerMockito.method(RestAPIClient.class, "getHttpClient"))
+      .toReturn(mockHttpClient);
     try {
       serviceNowMultiSourceConfig.validate(mockFailureCollector);
       Assert.fail("Exception is not thrown if connection is successful");
@@ -108,10 +122,10 @@ public class ServiceNowMultiSourceConfigTest {
     Mockito.when(restApi.getAccessToken()).thenReturn("token");
     PowerMockito.whenNew(ServiceNowTableAPIClientImpl.class).withAnyArguments().thenReturn(restApi);
     Map<String, String> headers = new HashMap<>();
-    Map<String, String> map = new HashMap<>();
-    List<Map<String, String>> result = new ArrayList<>();
-    map.put("key", "value");
-    result.add(map);
+    JsonObject jsonObject = new JsonObject();
+    List<JsonObject> result = new ArrayList<>();
+    jsonObject.addProperty("key", "value");
+    result.add(jsonObject);
     String responseBody = "{\n" +
       "    \"result\": [\n" +
       "        {\n" +
@@ -174,9 +188,13 @@ public class ServiceNowMultiSourceConfigTest {
       "        }\n" +
       "    ]\n" +
       "}";
-    RestAPIResponse restAPIResponse = new RestAPIResponse(headers, responseBody, null);
+    byte[] body = responseBody.getBytes(StandardCharsets.UTF_8);
+    InputStream inputStream = new ByteArrayInputStream(body);
+    HttpResponse httpResponse = new BasicHttpResponse(new BasicStatusLine(HttpVersion.HTTP_1_1, 200,
+      "OK"));
+    httpResponse.setEntity(new InputStreamEntity(inputStream, body.length));
+    RestAPIResponse restAPIResponse = new RestAPIResponse(headers, httpResponse, null);
     Mockito.when(restApi.executeGetWithRetries(Mockito.any())).thenReturn(restAPIResponse);
-    Mockito.when(restApi.parseResponseToResultListOfMap(restAPIResponse.getResponseBody())).thenReturn(result);
     serviceNowMultiSourceConfig.validate(mockFailureCollector);
     Assert.assertEquals(0, mockFailureCollector.getValidationFailures().size());
 
@@ -207,7 +225,12 @@ public class ServiceNowMultiSourceConfigTest {
     String responseBody = "{\n" +
       "    \"result\": []\n" +
       "}";
-    RestAPIResponse restAPIResponse = new RestAPIResponse(headers, responseBody, null);
+    byte[] body = responseBody.getBytes(StandardCharsets.UTF_8);
+    InputStream inputStream = new ByteArrayInputStream(body);
+    HttpResponse httpResponse = new BasicHttpResponse(new BasicStatusLine(HttpVersion.HTTP_1_1, 200,
+      "OK"));
+    httpResponse.setEntity(new InputStreamEntity(inputStream, body.length));
+    RestAPIResponse restAPIResponse = new RestAPIResponse(headers, httpResponse, null);
     Mockito.when(restApi.executeGetWithRetries(Mockito.any())).thenReturn(restAPIResponse);
     serviceNowMultiSourceConfig.validate(mockFailureCollector);
     Assert.assertEquals(1, mockFailureCollector.getValidationFailures().size());
@@ -235,10 +258,10 @@ public class ServiceNowMultiSourceConfigTest {
     Mockito.when(restApi.getAccessToken()).thenReturn("token");
     PowerMockito.whenNew(ServiceNowTableAPIClientImpl.class).withAnyArguments().thenReturn(restApi);
     Map<String, String> headers = new HashMap<>();
-    Map<String, String> map = new HashMap<>();
-    List<Map<String, String>> result = new ArrayList<>();
-    map.put("key", "value");
-    result.add(map);
+    JsonObject jsonObject = new JsonObject();
+    List<JsonObject> result = new ArrayList<>();
+    jsonObject.addProperty("key", "value");
+    result.add(jsonObject);
     String responseBody = "{\n" +
       "    \"result\": [\n" +
       "        {\n" +
@@ -301,9 +324,13 @@ public class ServiceNowMultiSourceConfigTest {
       "        }\n" +
       "    ]\n" +
       "}";
-    RestAPIResponse restAPIResponse = new RestAPIResponse(headers, responseBody, null);
+    byte[] body = responseBody.getBytes(StandardCharsets.UTF_8);
+    InputStream inputStream = new ByteArrayInputStream(body);
+    HttpResponse httpResponse = new BasicHttpResponse(new BasicStatusLine(HttpVersion.HTTP_1_1, 200,
+      "OK"));
+    httpResponse.setEntity(new InputStreamEntity(inputStream, body.length));
+    RestAPIResponse restAPIResponse = new RestAPIResponse(headers, httpResponse, null);
     Mockito.when(restApi.executeGetWithRetries(Mockito.any())).thenReturn(restAPIResponse);
-    Mockito.when(restApi.parseResponseToResultListOfMap(restAPIResponse.getResponseBody())).thenReturn(result);
     try {
       serviceNowMultiSourceConfig.validate(mockFailureCollector);
       Assert.fail("Exception is not thrown with valid reference name");
@@ -336,10 +363,10 @@ public class ServiceNowMultiSourceConfigTest {
     Mockito.when(restApi.getAccessToken()).thenReturn("token");
     PowerMockito.whenNew(ServiceNowTableAPIClientImpl.class).withAnyArguments().thenReturn(restApi);
     Map<String, String> headers = new HashMap<>();
-    Map<String, String> map = new HashMap<>();
-    List<Map<String, String>> result = new ArrayList<>();
-    map.put("key", "value");
-    result.add(map);
+    JsonObject jsonObject = new JsonObject();
+    List<JsonObject> result = new ArrayList<>();
+    jsonObject.addProperty("key", "value");
+    result.add(jsonObject);
     String responseBody = "{\n" +
       "    \"result\": [\n" +
       "        {\n" +
@@ -402,9 +429,13 @@ public class ServiceNowMultiSourceConfigTest {
       "        }\n" +
       "    ]\n" +
       "}";
-    RestAPIResponse restAPIResponse = new RestAPIResponse(headers, responseBody, null);
+    byte[] body = responseBody.getBytes(StandardCharsets.UTF_8);
+    InputStream inputStream = new ByteArrayInputStream(body);
+    HttpResponse httpResponse = new BasicHttpResponse(new BasicStatusLine(HttpVersion.HTTP_1_1, 200,
+      "OK"));
+    httpResponse.setEntity(new InputStreamEntity(inputStream, body.length));
+    RestAPIResponse restAPIResponse = new RestAPIResponse(headers, httpResponse, null);
     Mockito.when(restApi.executeGetWithRetries(Mockito.any())).thenReturn(restAPIResponse);
-    Mockito.when(restApi.parseResponseToResultListOfMap(restAPIResponse.getResponseBody())).thenReturn(result);
     serviceNowMultiSourceConfig.validate(mockFailureCollector);
     Assert.assertEquals(1, mockFailureCollector.getValidationFailures().size());
     Assert.assertEquals("Table name field must be specified.",

--- a/src/test/java/io/cdap/plugin/servicenow/source/ServiceNowMultiSourceTest.java
+++ b/src/test/java/io/cdap/plugin/servicenow/source/ServiceNowMultiSourceTest.java
@@ -16,6 +16,7 @@
 
 package io.cdap.plugin.servicenow.source;
 
+import com.google.gson.JsonObject;
 import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.etl.api.batch.BatchSourceContext;
 import io.cdap.cdap.etl.api.validation.ValidationException;
@@ -23,13 +24,16 @@ import io.cdap.cdap.etl.mock.common.MockArguments;
 import io.cdap.cdap.etl.mock.common.MockPipelineConfigurer;
 import io.cdap.cdap.etl.mock.validation.MockFailureCollector;
 import io.cdap.plugin.servicenow.apiclient.ServiceNowTableAPIClientImpl;
-import io.cdap.plugin.servicenow.connector.ServiceNowConnectorConfig;
 import io.cdap.plugin.servicenow.restapi.RestAPIResponse;
 import io.cdap.plugin.servicenow.util.ServiceNowTableInfo;
-import org.apache.http.HttpStatus;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpVersion;
 import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.entity.InputStreamEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.message.BasicHttpResponse;
+import org.apache.http.message.BasicStatusLine;
 import org.apache.oltu.oauth2.client.OAuthClient;
 import org.apache.oltu.oauth2.client.URLConnectionClient;
 import org.apache.oltu.oauth2.client.response.OAuthJSONAccessTokenResponse;
@@ -43,6 +47,9 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -89,10 +96,10 @@ public class ServiceNowMultiSourceTest {
     ServiceNowTableAPIClientImpl restApi = Mockito.mock(ServiceNowTableAPIClientImpl.class);
     Mockito.when(restApi.getAccessToken()).thenReturn("token");
     PowerMockito.whenNew(ServiceNowTableAPIClientImpl.class).withAnyArguments().thenReturn(restApi);
-    Map<String, String> map = new HashMap<>();
-    List<Map<String, String>> result = new ArrayList<>();
-    map.put("key", "value");
-    result.add(map);
+    JsonObject jsonObject = new JsonObject();
+    List<JsonObject> result = new ArrayList<>();
+    jsonObject.addProperty("key", "value");
+    result.add(jsonObject);
     Map<String, String> headers = new HashMap<>();
     String responseBody = "{\n" +
       "    \"result\": [\n" +
@@ -156,9 +163,13 @@ public class ServiceNowMultiSourceTest {
       "        }\n" +
       "    ]\n" +
       "}";
-    RestAPIResponse restAPIResponse = new RestAPIResponse(headers, responseBody, null);
+    byte[] body = responseBody.getBytes(StandardCharsets.UTF_8);
+    InputStream inputStream = new ByteArrayInputStream(body);
+    HttpResponse httpResponse = new BasicHttpResponse(new BasicStatusLine(HttpVersion.HTTP_1_1, 200,
+      "OK"));
+    httpResponse.setEntity(new InputStreamEntity(inputStream, body.length));
+    RestAPIResponse restAPIResponse = new RestAPIResponse(headers, httpResponse, null);
     Mockito.when(restApi.executeGetWithRetries(Mockito.any())).thenReturn(restAPIResponse);
-    Mockito.when(restApi.parseResponseToResultListOfMap(restAPIResponse.getResponseBody())).thenReturn(result);
     serviceNowMultiSource.configurePipeline(mockPipelineConfigurer);
     Assert.assertNull(mockPipelineConfigurer.getOutputSchema());
     Assert.assertEquals(0, mockFailureCollector.getValidationFailures().size());
@@ -171,14 +182,18 @@ public class ServiceNowMultiSourceTest {
     ServiceNowTableAPIClientImpl restApi = Mockito.mock(ServiceNowTableAPIClientImpl.class);
     Mockito.when(restApi.getAccessToken()).thenReturn("token");
     PowerMockito.whenNew(ServiceNowTableAPIClientImpl.class).withAnyArguments().thenReturn(restApi);
-    List<Map<String, String>> result = new ArrayList<>();
+    List<JsonObject> result = new ArrayList<>();
     Map<String, String> headers = new HashMap<>();
     String responseBody = "{\n" +
       "    \"result\": []\n" +
       "}";
-    RestAPIResponse restAPIResponse = new RestAPIResponse(headers, responseBody, null);
+    byte[] body = responseBody.getBytes(StandardCharsets.UTF_8);
+    InputStream inputStream = new ByteArrayInputStream(body);
+    HttpResponse httpResponse = new BasicHttpResponse(new BasicStatusLine(HttpVersion.HTTP_1_1, 200,
+      "OK"));
+    httpResponse.setEntity(new InputStreamEntity(inputStream, body.length));
+    RestAPIResponse restAPIResponse = new RestAPIResponse(headers, httpResponse, null);
     Mockito.when(restApi.executeGetWithRetries(Mockito.any())).thenReturn(restAPIResponse);
-    Mockito.when(restApi.parseResponseToResultListOfMap(restAPIResponse.getResponseBody())).thenReturn(result);
     try {
       serviceNowMultiSource.configurePipeline(mockPipelineConfigurer);
       Assert.fail("Exception is not thrown for Non-Empty Tables");
@@ -211,10 +226,10 @@ public class ServiceNowMultiSourceTest {
     Mockito.when(context.getArguments()).thenReturn(mockArguments);
     ServiceNowTableAPIClientImpl restApi = Mockito.mock(ServiceNowTableAPIClientImpl.class);
     PowerMockito.whenNew(ServiceNowTableAPIClientImpl.class).withAnyArguments().thenReturn(restApi);
-    List<Map<String, String>> result = new ArrayList<>();
-    Map<String, String> map = new HashMap<>();
-    map.put("key", "value");
-    result.add(map);
+    JsonObject jsonObject = new JsonObject();
+    List<JsonObject> result = new ArrayList<>();
+    jsonObject.addProperty("key", "value");
+    result.add(jsonObject);
     Map<String, String> headers = new HashMap<>();
     String responseBody = "{\n" +
       "    \"result\": [\n" +
@@ -278,11 +293,15 @@ public class ServiceNowMultiSourceTest {
       "        }\n" +
       "    ]\n" +
       "}";
+    byte[] body = responseBody.getBytes(StandardCharsets.UTF_8);
+    InputStream inputStream = new ByteArrayInputStream(body);
+    HttpResponse httpResponse = new BasicHttpResponse(new BasicStatusLine(HttpVersion.HTTP_1_1, 200,
+      "OK"));
+    httpResponse.setEntity(new InputStreamEntity(inputStream, body.length));
     PowerMockito.mockStatic(ServiceNowMultiInputFormat.class);
     Mockito.when(ServiceNowMultiInputFormat.setInput(Mockito.any(), Mockito.any())).thenReturn((tableInfo));
-    RestAPIResponse restAPIResponse = new RestAPIResponse(headers, responseBody, null);
+    RestAPIResponse restAPIResponse = new RestAPIResponse(headers, httpResponse, null);
     Mockito.when(restApi.executeGetWithRetries(Mockito.any())).thenReturn(restAPIResponse);
-    Mockito.when(restApi.parseResponseToResultListOfMap(restAPIResponse.getResponseBody())).thenReturn(result);
     OAuthClient oAuthClient = Mockito.mock(OAuthClient.class);
     PowerMockito.whenNew(OAuthClient.class).
       withArguments(Mockito.any(URLConnectionClient.class)).thenReturn(oAuthClient);
@@ -298,8 +317,8 @@ public class ServiceNowMultiSourceTest {
     PowerMockito.mockStatic(ServiceNowInputFormat.class);
     PowerMockito.when(HttpClientBuilder.create()).thenReturn(httpClientBuilder);
     Mockito.when(httpClientBuilder.build()).thenReturn(httpClient);
-    CloseableHttpResponse httpResponse = Mockito.mock(CloseableHttpResponse.class);
-    Mockito.when(httpClient.execute(Mockito.any())).thenReturn(httpResponse);
+    CloseableHttpResponse closeableHttpResponse = Mockito.mock(CloseableHttpResponse.class);
+    Mockito.when(httpClient.execute(Mockito.any())).thenReturn(closeableHttpResponse);
     PowerMockito.when(RestAPIResponse.parse(ArgumentMatchers.any(), ArgumentMatchers.anyString())).
       thenReturn(response);
     serviceNowMultiSource.prepareRun(context);

--- a/src/test/java/io/cdap/plugin/servicenow/source/ServiceNowRecordReaderTest.java
+++ b/src/test/java/io/cdap/plugin/servicenow/source/ServiceNowRecordReaderTest.java
@@ -16,6 +16,7 @@
 
 package io.cdap.plugin.servicenow.source;
 
+import com.google.gson.JsonObject;
 import io.cdap.cdap.api.data.format.StructuredRecord;
 import io.cdap.cdap.api.data.format.UnexpectedFormatException;
 import io.cdap.cdap.api.data.schema.Schema;
@@ -25,10 +26,16 @@ import io.cdap.plugin.servicenow.apiclient.ServiceNowTableAPIClientImpl;
 import io.cdap.plugin.servicenow.apiclient.ServiceNowTableDataResponse;
 import io.cdap.plugin.servicenow.connector.ServiceNowConnectorConfig;
 import io.cdap.plugin.servicenow.connector.ServiceNowRecordConverter;
+import io.cdap.plugin.servicenow.restapi.RestAPIResponse;
 import io.cdap.plugin.servicenow.util.ServiceNowColumn;
 import io.cdap.plugin.servicenow.util.ServiceNowConstants;
 import io.cdap.plugin.servicenow.util.SourceQueryMode;
 import io.cdap.plugin.servicenow.util.SourceValueType;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpVersion;
+import org.apache.http.entity.InputStreamEntity;
+import org.apache.http.message.BasicHttpResponse;
+import org.apache.http.message.BasicStatusLine;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -39,11 +46,17 @@ import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -51,7 +64,6 @@ import java.util.Map;
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ServiceNowTableAPIClientImpl.class, ServiceNowSourceConfig.class, ServiceNowRecordReader.class})
 public class ServiceNowRecordReaderTest {
-
   private static final String CLIENT_ID = "client_id";
   private static final String CLIENT_SECRET = "client_secret";
   private static final String REST_API_ENDPOINT = "https://ven05127.service-now.com";
@@ -130,10 +142,10 @@ public class ServiceNowRecordReaderTest {
     Schema fieldSchema = Schema.recordOf("record", Schema.Field.of("TimeField",
                                                                    Schema.of(Schema.LogicalType.TIMESTAMP_MILLIS)));
     StructuredRecord.Builder recordBuilder = StructuredRecord.builder(fieldSchema);
-    Map<String, String> map = new HashMap<>();
-    map.put("TimeField", "value");
+    JsonObject jsonObject = new JsonObject();
+    jsonObject.addProperty("TimeField", "value");
     thrown.expect(IllegalStateException.class);
-    ServiceNowRecordConverter.convertToValue("TimeField", fieldSchema, map, recordBuilder, false);
+    ServiceNowRecordConverter.convertToValue("TimeField", fieldSchema, jsonObject, recordBuilder, false);
   }
 
   @Test
@@ -156,12 +168,12 @@ public class ServiceNowRecordReaderTest {
     );
 
     for (String value : dateTimeValues) {
-      Map<String, String> inputMap = new HashMap<>();
-      inputMap.put("DateTimeField", value);
+      JsonObject jsonObject = new JsonObject();
+      jsonObject.addProperty("DateTimeField", value);
 
       StructuredRecord.Builder recordBuilder = StructuredRecord.builder(recordSchema);
       try {
-        ServiceNowRecordConverter.convertToValue("DateTimeField", fieldSchema, inputMap, recordBuilder, false);
+        ServiceNowRecordConverter.convertToValue("DateTimeField", fieldSchema, jsonObject, recordBuilder, false);
         StructuredRecord record = recordBuilder.build();
         Assert.assertNotNull("Parsed datetime should not be null for input: " + value,
             record.get("DateTimeField"));
@@ -187,12 +199,12 @@ public class ServiceNowRecordReaderTest {
     );
 
     for (String value : dateValues) {
-      Map<String, String> inputMap = new HashMap<>();
-      inputMap.put("DateField", value);
+      JsonObject jsonObject = new JsonObject();
+      jsonObject.addProperty("DateField", value);
 
       StructuredRecord.Builder recordBuilder = StructuredRecord.builder(recordSchema);
       try {
-        ServiceNowRecordConverter.convertToValue("DateField", fieldSchema, inputMap, recordBuilder, false);
+        ServiceNowRecordConverter.convertToValue("DateField", fieldSchema, jsonObject, recordBuilder, false);
         StructuredRecord record = recordBuilder.build();
         Assert.assertNotNull("Parsed date should not be null for input: " + value,
             record.get("DateField"));
@@ -216,12 +228,12 @@ public class ServiceNowRecordReaderTest {
     );
 
     for (String value : timeValues) {
-      Map<String, String> inputMap = new HashMap<>();
-      inputMap.put("TimeField", value);
+      JsonObject jsonObject = new JsonObject();
+      jsonObject.addProperty("TimeField", value);
 
       StructuredRecord.Builder recordBuilder = StructuredRecord.builder(recordSchema);
       try {
-        ServiceNowRecordConverter.convertToValue("TimeField", fieldSchema, inputMap, recordBuilder, false);
+        ServiceNowRecordConverter.convertToValue("TimeField", fieldSchema, jsonObject, recordBuilder, false);
         StructuredRecord record = recordBuilder.build();
         Assert.assertNotNull("Parsed date should not be null for input: " + value,
             record.get("TimeField"));
@@ -238,12 +250,12 @@ public class ServiceNowRecordReaderTest {
       Schema.Field.of("ArrayField", Schema.arrayOf(Schema.of(Schema.Type.STRING))
     ));
     Schema fieldSchema = recordSchema.getField("ArrayField").getSchema();
-    Map<String, String> inputMap = new HashMap<>();
-    inputMap.put("ArrayField", "\"service_sys_id_1_1\",\"service_sys_id_2_1\"");
+    JsonObject jsonObject = new JsonObject();
+    jsonObject.addProperty("ArrayField", "\"service_sys_id_1_1\",\"service_sys_id_2_1\"");
     StructuredRecord.Builder recordBuilder = StructuredRecord.builder(recordSchema);
-    ServiceNowRecordConverter.convertToValue("ArrayField", fieldSchema, inputMap, recordBuilder, true);
+    ServiceNowRecordConverter.convertToValue("ArrayField", fieldSchema, jsonObject, recordBuilder, true);
     StructuredRecord record = recordBuilder.build();
-    Assert.assertEquals(inputMap.get("ArrayField"), record.get("ArrayField"));
+    Assert.assertEquals(jsonObject.get("ArrayField").getAsString(), record.get("ArrayField"));
   }
 
   @Test
@@ -253,12 +265,13 @@ public class ServiceNowRecordReaderTest {
       Schema.Field.of("ArrayField", Schema.arrayOf(Schema.of(Schema.Type.STRING))
       ));
     Schema fieldSchema = recordSchema.getField("ArrayField").getSchema();
-    Map<String, String> inputMap = new HashMap<>();
-    inputMap.put("ArrayField", "\"service_sys_id_1_1\",\"service_sys_id_2_1\"");
+    JsonObject jsonObject = new JsonObject();
+    jsonObject.addProperty("ArrayField", "\"service_sys_id_1_1\",\"service_sys_id_2_1\"");
     StructuredRecord.Builder recordBuilder = StructuredRecord.builder(recordSchema);
-    ServiceNowRecordConverter.convertToValue("ArrayField", fieldSchema, inputMap, recordBuilder, false);
+    ServiceNowRecordConverter.convertToValue("ArrayField", fieldSchema, jsonObject, recordBuilder, false);
     StructuredRecord record = recordBuilder.build();
-    Assert.assertEquals(Arrays.asList(inputMap.get("ArrayField").split(",")), record.get("ArrayField"));
+    Assert.assertEquals(Arrays.asList(jsonObject.get("ArrayField").getAsString().split(",")),
+      record.get("ArrayField"));
   }
 
   @Test
@@ -289,30 +302,58 @@ public class ServiceNowRecordReaderTest {
     ServiceNowTableAPIClientImpl restApi = Mockito.mock(ServiceNowTableAPIClientImpl.class);
     ServiceNowInputSplit split = new ServiceNowInputSplit(tableName, 1, null);
     ServiceNowRecordReader serviceNowRecordReader = new ServiceNowRecordReader(serviceNowSourceConfig);
-    List<Map<String, String>> results = new ArrayList<>();
-    Map<String, String> map = new HashMap<>();
-    map.put("calendar_integration", "1");
-    map.put("country", "India");
-    map.put("sys_updated_on", "2019-04-05 21:54:45");
-    map.put("web_service_access_only", "false");
-    map.put("notification", "2");
-    map.put("enable_multifactor_authn", "false");
-    map.put("sys_updated_by", "system");
-    map.put("sys_created_on", "2019-04-05 21:09:12");
-    results.add(map);
-    ServiceNowTableDataResponse response = new ServiceNowTableDataResponse();
-    ServiceNowColumn column1 = new ServiceNowColumn("calendar_integration", "integer");
-    ServiceNowColumn column2 = new ServiceNowColumn("vip", "boolean");
-    List<ServiceNowColumn> columns = new ArrayList<>();
-    columns.add(column1);
-    columns.add(column2);
-    response.setColumns(columns);
-    response.setResult(results);
-    response.setTotalRecordCount(1);
+    RestAPIResponse mockResponse = Mockito.mock(RestAPIResponse.class);
+    String responseBody = "{\n" +
+      "  \"result\": [\n" +
+      "    {\n" +
+      "      \"bill_to\": \"\",\n" +
+      "      \"init_request\": \"\",\n" +
+      "      \"short_description\": \"\",\n" +
+      "      \"total_cost\": \"0\",\n" +
+      "      \"due_by\": \"\",\n" +
+      "      \"description\": \"\",\n" +
+      "      \"requested_for\": \"\",\n" +
+      "      \"sys_updated_on\": \"2022-06-16 18:56:23\",\n" +
+      "      \"budget_number\": \"\",\n" +
+      "      \"number\": \"RCS397871\",\n" +
+      "      \"sys_id\": \"00000b7287405910827733373cbb35d5\",\n" +
+      "      \"sys_updated_by\": \"pipeline.user.1\",\n" +
+      "      \"shipping\": \"\",\n" +
+      "      \"terms\": \"\",\n" +
+      "      \"sys_created_on\": \"2022-06-16 18:56:23\",\n" +
+      "      \"vendor\": \"\",\n" +
+      "      \"sys_domain\": \"global\",\n" +
+      "      \"department\": \"\",\n" +
+      "      \"sys_created_by\": \"pipeline.user.1\",\n" +
+      "      \"assigned_to\": \"\",\n" +
+      "      \"ordered\": \"\",\n" +
+      "      \"po_date\": \"2022-06-16 18:56:23\",\n" +
+      "      \"vendor_contract\": \"\",\n" +
+      "      \"contract\": \"\",\n" +
+      "      \"expected_delivery\": \"\",\n" +
+      "      \"sys_mod_count\": \"0\",\n" +
+      "      \"received\": \"2158-05-10 17:14:20\",\n" +
+      "      \"asset_operation\": \"\",\n" +
+      "      \"sys_tags\": \"\",\n" +
+      "      \"requested\": \"2022-06-16 18:56:23\",\n" +
+      "      \"requested_by\": \"\",\n" +
+      "      \"ship_rate\": \"0\",\n" +
+      "      \"location\": \"\",\n" +
+      "      \"vendor_account\": \"\",\n" +
+      "      \"ship_to\": \"\",\n" +
+      "      \"status\": \"requested\"\n" +
+      "    }\n" +
+      "  ]\n" +
+      "}";
+    byte[] body = responseBody.getBytes(StandardCharsets.UTF_8);
+    InputStream inputStream = new ByteArrayInputStream(body);
+    HttpResponse httpResponse = new BasicHttpResponse(new BasicStatusLine(HttpVersion.HTTP_1_1, 200,
+      "OK"));
+    httpResponse.setEntity(new InputStreamEntity(inputStream, body.length));
+    RestAPIResponse restAPIResponse = new RestAPIResponse(Collections.emptyMap(), httpResponse, null);
     PowerMockito.whenNew(ServiceNowTableAPIClientImpl.class).withAnyArguments().thenReturn(restApi);
     Mockito.when(restApi.fetchTableRecordsRetryableMode(tableName, serviceNowSourceConfig.getValueType(),
-            split.getFilterQuery(), split.getOffset(),
-                                                        serviceNowSourceConfig.getPageSize())).thenReturn(results);
+      split.getFilterQuery(), split.getOffset(), serviceNowSourceConfig.getPageSize())).thenReturn(restAPIResponse);
     Mockito.when(restApi.fetchTableSchema(tableName, valueType))
       .thenReturn(Schema.recordOf(Schema.Field.of("calendar_integration", Schema.of(Schema.Type.STRING))));
     serviceNowRecordReader.initialize(split);
@@ -341,30 +382,58 @@ public class ServiceNowRecordReaderTest {
     ServiceNowTableAPIClientImpl restApi = Mockito.mock(ServiceNowTableAPIClientImpl.class);
     ServiceNowInputSplit split = new ServiceNowInputSplit(tableName, 1, null);
     ServiceNowRecordReader serviceNowRecordReader = new ServiceNowRecordReader(serviceNowSourceConfig);
-    List<Map<String, String>> results = new ArrayList<>();
-    Map<String, String> map = new HashMap<>();
-    map.put("calendar_integration", "1");
-    map.put("country", "India");
-    map.put("sys_updated_on", "2019-04-05 21:54:45");
-    map.put("web_service_access_only", "false");
-    map.put("notification", "2");
-    map.put("enable_multifactor_authn", "false");
-    map.put("sys_updated_by", "system");
-    map.put("sys_created_on", "2019-04-05 21:09:12");
-    results.add(map);
-    ServiceNowTableDataResponse response = new ServiceNowTableDataResponse();
-    ServiceNowColumn column1 = new ServiceNowColumn("calendar_integration", "integer");
-    ServiceNowColumn column2 = new ServiceNowColumn("vip", "boolean");
-    List<ServiceNowColumn> columns = new ArrayList<>();
-    columns.add(column1);
-    columns.add(column2);
-    response.setColumns(columns);
-    response.setResult(results);
-    response.setTotalRecordCount(1);
+    String responseBody = "{\n" +
+      "  \"result\": [\n" +
+      "    {\n" +
+      "      \"bill_to\": \"\",\n" +
+      "      \"init_request\": \"\",\n" +
+      "      \"short_description\": \"\",\n" +
+      "      \"total_cost\": \"0\",\n" +
+      "      \"due_by\": \"\",\n" +
+      "      \"description\": \"\",\n" +
+      "      \"requested_for\": \"\",\n" +
+      "      \"sys_updated_on\": \"2022-06-16 18:56:23\",\n" +
+      "      \"budget_number\": \"\",\n" +
+      "      \"number\": \"RCS397871\",\n" +
+      "      \"sys_id\": \"00000b7287405910827733373cbb35d5\",\n" +
+      "      \"sys_updated_by\": \"pipeline.user.1\",\n" +
+      "      \"shipping\": \"\",\n" +
+      "      \"terms\": \"\",\n" +
+      "      \"sys_created_on\": \"2022-06-16 18:56:23\",\n" +
+      "      \"vendor\": \"\",\n" +
+      "      \"sys_domain\": \"global\",\n" +
+      "      \"department\": \"\",\n" +
+      "      \"sys_created_by\": \"pipeline.user.1\",\n" +
+      "      \"assigned_to\": \"\",\n" +
+      "      \"ordered\": \"\",\n" +
+      "      \"po_date\": \"2022-06-16 18:56:23\",\n" +
+      "      \"vendor_contract\": \"\",\n" +
+      "      \"contract\": \"\",\n" +
+      "      \"expected_delivery\": \"\",\n" +
+      "      \"sys_mod_count\": \"0\",\n" +
+      "      \"received\": \"2158-05-10 17:14:20\",\n" +
+      "      \"asset_operation\": \"\",\n" +
+      "      \"sys_tags\": \"\",\n" +
+      "      \"requested\": \"2022-06-16 18:56:23\",\n" +
+      "      \"requested_by\": \"\",\n" +
+      "      \"ship_rate\": \"0\",\n" +
+      "      \"location\": \"\",\n" +
+      "      \"vendor_account\": \"\",\n" +
+      "      \"ship_to\": \"\",\n" +
+      "      \"status\": \"requested\"\n" +
+      "    }\n" +
+      "  ]\n" +
+      "}";
+    byte[] body = responseBody.getBytes(StandardCharsets.UTF_8);
+    InputStream inputStream = new ByteArrayInputStream(body);
+    HttpResponse httpResponse = new BasicHttpResponse(new BasicStatusLine(HttpVersion.HTTP_1_1, 200,
+      "OK"));
+    httpResponse.setEntity(new InputStreamEntity(inputStream, body.length));
+    RestAPIResponse restAPIResponse = new RestAPIResponse(Collections.emptyMap(), httpResponse, null);
     PowerMockito.whenNew(ServiceNowTableAPIClientImpl.class).withAnyArguments().thenReturn(restApi);
     Mockito.when(restApi.fetchTableRecordsRetryableMode(tableName, serviceNowSourceConfig.getValueType(),
                                                         split.getFilterQuery(), split.getOffset(),
-                                                        serviceNowSourceConfig.getPageSize())).thenReturn(results);
+        serviceNowSourceConfig.getPageSize())).thenReturn(restAPIResponse);
     Mockito.when(restApi.fetchTableSchema(tableName, serviceNowSourceConfig.getValueType()))
       .thenReturn(Schema.recordOf(Schema.Field.of("calendar_integration", Schema.of(Schema.Type.STRING))));
     serviceNowRecordReader.initialize(split);
@@ -380,7 +449,7 @@ public class ServiceNowRecordReaderTest {
       .setPassword(PASSWORD)
       .setClientId(CLIENT_ID)
       .setClientSecret(CLIENT_SECRET)
-      .setTableName("")
+      .setTableName("abc")
       .setValueType("Actual")
       .setStartDate("2021-01-01")
       .setEndDate("2022-02-18")
@@ -392,11 +461,25 @@ public class ServiceNowRecordReaderTest {
     ServiceNowInputSplit split = new ServiceNowInputSplit(tableName, 1, null);
     ServiceNowRecordReader serviceNowRecordReader = new ServiceNowRecordReader(serviceNowSourceConfig);
     List<Map<String, String>> results = new ArrayList<>();
+    String responseBody = "{\n    " +
+      "\"error\": " +
+      "{\n        " +
+      "\"message\": \"Invalid table abc\",\n" +
+      "        \"detail\": null\n    " +
+      "},\n    " +
+      "\"status\": \"failure\"\n" +
+      "}";
+    byte[] body = responseBody.getBytes(StandardCharsets.UTF_8);
+    InputStream inputStream = new ByteArrayInputStream(body);
+    HttpResponse httpResponse = new BasicHttpResponse(new BasicStatusLine(HttpVersion.HTTP_1_1, 200,
+      "OK"));
+    httpResponse.setEntity(new InputStreamEntity(inputStream, body.length));
+    RestAPIResponse restAPIResponse = new RestAPIResponse(Collections.emptyMap(), httpResponse, null);
     PowerMockito.whenNew(ServiceNowTableAPIClientImpl.class).withAnyArguments().thenReturn(restApi);
-    Mockito.when(restApi.fetchTableRecords(tableName, serviceNowSourceConfig.getValueType(),
-                                           split.getFilterQuery(),
+    Mockito.when(restApi.fetchTableRecordsRetryableMode(tableName, serviceNowSourceConfig.getValueType(),
+                                                        split.getFilterQuery(),
                                            split.getOffset(),
-                                           serviceNowSourceConfig.getPageSize())).thenReturn(results);
+                                           serviceNowSourceConfig.getPageSize())).thenReturn(restAPIResponse);
     ServiceNowTableDataResponse response = new ServiceNowTableDataResponse();
     response.setResult(results);
     Mockito.when(restApi.fetchTableSchema(tableName, serviceNowSourceConfig.getValueType()))

--- a/src/test/java/io/cdap/plugin/servicenow/source/ServiceNowSourceConfigTest.java
+++ b/src/test/java/io/cdap/plugin/servicenow/source/ServiceNowSourceConfigTest.java
@@ -23,7 +23,6 @@ import io.cdap.cdap.etl.api.validation.ValidationFailure;
 import io.cdap.cdap.etl.mock.validation.MockFailureCollector;
 import io.cdap.plugin.servicenow.apiclient.ServiceNowAPIException;
 import io.cdap.plugin.servicenow.apiclient.ServiceNowTableAPIClientImpl;
-import io.cdap.plugin.servicenow.connector.ServiceNowConnectorConfig;
 import io.cdap.plugin.servicenow.restapi.RestAPIResponse;
 import io.cdap.plugin.servicenow.util.ServiceNowConstants;
 import io.cdap.plugin.servicenow.util.SourceApplication;
@@ -31,7 +30,11 @@ import io.cdap.plugin.servicenow.util.SourceQueryMode;
 import io.cdap.plugin.servicenow.util.SourceValueType;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
+import org.apache.http.HttpVersion;
 import org.apache.http.StatusLine;
+import org.apache.http.entity.InputStreamEntity;
+import org.apache.http.message.BasicHttpResponse;
+import org.apache.http.message.BasicStatusLine;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -42,7 +45,9 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
-import java.io.IOException;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -624,7 +629,12 @@ public class ServiceNowSourceConfigTest {
     String responseBody = "{\n" +
       "    \"result\": []\n" +
       "}";
-    RestAPIResponse restAPIResponse = new RestAPIResponse(headers, responseBody, null);
+    byte[] body = responseBody.getBytes(StandardCharsets.UTF_8);
+    InputStream inputStream = new ByteArrayInputStream(body);
+    HttpResponse httpResponse = new BasicHttpResponse(new BasicStatusLine(HttpVersion.HTTP_1_1, 200,
+      "OK"));
+    httpResponse.setEntity(new InputStreamEntity(inputStream, body.length));
+    RestAPIResponse restAPIResponse = new RestAPIResponse(headers, httpResponse, null);
     Mockito.when(restApi.executeGetWithRetries(Mockito.any())).thenReturn(restAPIResponse);
     config.validate(mockFailureCollector);
     Assert.assertEquals(1, mockFailureCollector.getValidationFailures().size());

--- a/src/test/java/io/cdap/plugin/servicenow/source/ServiceNowSourceTest.java
+++ b/src/test/java/io/cdap/plugin/servicenow/source/ServiceNowSourceTest.java
@@ -16,6 +16,7 @@
 
 package io.cdap.plugin.servicenow.source;
 
+import com.google.gson.JsonObject;
 import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.etl.api.batch.BatchSourceContext;
 import io.cdap.cdap.etl.api.validation.ValidationException;
@@ -23,14 +24,17 @@ import io.cdap.cdap.etl.mock.common.MockArguments;
 import io.cdap.cdap.etl.mock.common.MockPipelineConfigurer;
 import io.cdap.cdap.etl.mock.validation.MockFailureCollector;
 import io.cdap.plugin.servicenow.apiclient.ServiceNowTableAPIClientImpl;
-import io.cdap.plugin.servicenow.connector.ServiceNowConnectorConfig;
 import io.cdap.plugin.servicenow.restapi.RestAPIResponse;
 import io.cdap.plugin.servicenow.util.ServiceNowTableInfo;
 
-import org.apache.http.HttpStatus;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpVersion;
 import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.entity.InputStreamEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.message.BasicHttpResponse;
+import org.apache.http.message.BasicStatusLine;
 import org.apache.oltu.oauth2.client.OAuthClient;
 import org.apache.oltu.oauth2.client.URLConnectionClient;
 import org.apache.oltu.oauth2.client.response.OAuthJSONAccessTokenResponse;
@@ -44,6 +48,9 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -101,10 +108,10 @@ public class ServiceNowSourceTest {
     ServiceNowTableAPIClientImpl restApi = Mockito.mock(ServiceNowTableAPIClientImpl.class);
     Mockito.when(restApi.getAccessToken()).thenReturn("token1");
     PowerMockito.whenNew(ServiceNowTableAPIClientImpl.class).withAnyArguments().thenReturn(restApi);
-    Map<String, String> map = new HashMap<>();
-    List<Map<String, String>> result = new ArrayList<>();
-    map.put("key", "value");
-    result.add(map);
+    JsonObject jsonObject = new JsonObject();
+    List<JsonObject> result = new ArrayList<>();
+    jsonObject.addProperty("key", "value");
+    result.add(jsonObject);
     Map<String, String> headers = new HashMap<>();
     String responseBody = "{\n" +
       "    \"result\": [\n" +
@@ -168,12 +175,16 @@ public class ServiceNowSourceTest {
       "        }\n" +
       "    ]\n" +
       "}";
+    byte[] body = responseBody.getBytes(StandardCharsets.UTF_8);
+    InputStream inputStream = new ByteArrayInputStream(body);
+    HttpResponse httpResponse = new BasicHttpResponse(new BasicStatusLine(HttpVersion.HTTP_1_1, 200,
+      "OK"));
+    httpResponse.setEntity(new InputStreamEntity(inputStream, body.length));
     PowerMockito.mockStatic(ServiceNowInputFormat.class);
     Mockito.when(ServiceNowInputFormat.fetchTableInfo(Mockito.any(), Mockito.any(), Mockito.anyString(),
       Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any())).thenReturn(tableInfo);
-    RestAPIResponse restAPIResponse = new RestAPIResponse(headers, responseBody, null);
+    RestAPIResponse restAPIResponse = new RestAPIResponse(headers, httpResponse, null);
     Mockito.when(restApi.executeGetWithRetries(Mockito.any())).thenReturn(restAPIResponse);
-    Mockito.when(restApi.parseResponseToResultListOfMap(restAPIResponse.getResponseBody())).thenReturn(result);
     OAuthClient oAuthClient = Mockito.mock(OAuthClient.class);
     PowerMockito.whenNew(OAuthClient.class).
       withArguments(Mockito.any(URLConnectionClient.class)).thenReturn(oAuthClient);
@@ -188,8 +199,8 @@ public class ServiceNowSourceTest {
     PowerMockito.mockStatic(RestAPIResponse.class);
     PowerMockito.when(HttpClientBuilder.create()).thenReturn(httpClientBuilder);
     Mockito.when(httpClientBuilder.build()).thenReturn(httpClient);
-    CloseableHttpResponse httpResponse = Mockito.mock(CloseableHttpResponse.class);
-    Mockito.when(httpClient.execute(Mockito.any())).thenReturn(httpResponse);
+    CloseableHttpResponse closeableHttpResponse = Mockito.mock(CloseableHttpResponse.class);
+    Mockito.when(httpClient.execute(Mockito.any())).thenReturn(closeableHttpResponse);
     PowerMockito.when(RestAPIResponse.parse(ArgumentMatchers.any(), ArgumentMatchers.anyString())).
       thenReturn(response);
     serviceNowSource.configurePipeline(mockPipelineConfigurer);
@@ -204,14 +215,18 @@ public class ServiceNowSourceTest {
     ServiceNowTableAPIClientImpl restApi = Mockito.mock(ServiceNowTableAPIClientImpl.class);
     Mockito.when(restApi.getAccessToken()).thenReturn("token");
     PowerMockito.whenNew(ServiceNowTableAPIClientImpl.class).withAnyArguments().thenReturn(restApi);
-    List<Map<String, String>> result = new ArrayList<>();
+    List<JsonObject> result = new ArrayList<>();
     Map<String, String> headers = new HashMap<>();
     String responseBody = "{\n" +
       "    \"result\": []\n" +
       "}";
-    RestAPIResponse restAPIResponse = new RestAPIResponse(headers, responseBody, null);
+    byte[] body = responseBody.getBytes(StandardCharsets.UTF_8);
+    InputStream inputStream = new ByteArrayInputStream(body);
+    HttpResponse httpResponse = new BasicHttpResponse(new BasicStatusLine(HttpVersion.HTTP_1_1, 200,
+      "OK"));
+    httpResponse.setEntity(new InputStreamEntity(inputStream, body.length));
+    RestAPIResponse restAPIResponse = new RestAPIResponse(headers, httpResponse, null);
     Mockito.when(restApi.executeGetWithRetries(Mockito.any())).thenReturn(restAPIResponse);
-    Mockito.when(restApi.parseResponseToResultListOfMap(restAPIResponse.getResponseBody())).thenReturn(result);
     try {
       serviceNowSource.configurePipeline(mockPipelineConfigurer);
       Assert.fail("Exception is not thrown for Non-Empty Tables");
@@ -230,10 +245,10 @@ public class ServiceNowSourceTest {
     Mockito.when(context.getArguments()).thenReturn(mockArguments);
     ServiceNowTableAPIClientImpl restApi = Mockito.mock(ServiceNowTableAPIClientImpl.class);
     PowerMockito.whenNew(ServiceNowTableAPIClientImpl.class).withAnyArguments().thenReturn(restApi);
-    List<Map<String, String>> result = new ArrayList<>();
-    Map<String, String> map = new HashMap<>();
-    map.put("key", "value");
-    result.add(map);
+    JsonObject jsonObject = new JsonObject();
+    List<JsonObject> result = new ArrayList<>();
+    jsonObject.addProperty("key", "value");
+    result.add(jsonObject);
     Map<String, String> headers = new HashMap<>();
     String responseBody = "{\n" +
       "    \"result\": [\n" +
@@ -297,9 +312,13 @@ public class ServiceNowSourceTest {
       "        }\n" +
       "    ]\n" +
       "}";
-    RestAPIResponse restAPIResponse = new RestAPIResponse(headers, responseBody, null);
+    byte[] body = responseBody.getBytes(StandardCharsets.UTF_8);
+    InputStream inputStream = new ByteArrayInputStream(body);
+    HttpResponse httpResponse = new BasicHttpResponse(new BasicStatusLine(HttpVersion.HTTP_1_1, 200,
+      "OK"));
+    httpResponse.setEntity(new InputStreamEntity(inputStream, body.length));
+    RestAPIResponse restAPIResponse = new RestAPIResponse(headers, httpResponse, null);
     PowerMockito.when(restApi.executeGetWithRetries(Mockito.any())).thenReturn(restAPIResponse);
-    Mockito.when(restApi.parseResponseToResultListOfMap(restAPIResponse.getResponseBody())).thenReturn(result);
     OAuthClient oAuthClient = Mockito.mock(OAuthClient.class);
     PowerMockito.whenNew(OAuthClient.class).
       withArguments(Mockito.any(URLConnectionClient.class)).thenReturn(oAuthClient);
@@ -315,8 +334,8 @@ public class ServiceNowSourceTest {
     PowerMockito.mockStatic(ServiceNowInputFormat.class);
     PowerMockito.when(HttpClientBuilder.create()).thenReturn(httpClientBuilder);
     Mockito.when(httpClientBuilder.build()).thenReturn(httpClient);
-    CloseableHttpResponse httpResponse = Mockito.mock(CloseableHttpResponse.class);
-    Mockito.when(httpClient.execute(Mockito.any())).thenReturn(httpResponse);
+    CloseableHttpResponse closeableHttpResponse = Mockito.mock(CloseableHttpResponse.class);
+    Mockito.when(httpClient.execute(Mockito.any())).thenReturn(closeableHttpResponse);
     PowerMockito.when(RestAPIResponse.parse(ArgumentMatchers.any(), ArgumentMatchers.anyString())).
       thenReturn(response);
     serviceNowSource.prepareRun(context);


### PR DESCRIPTION
[PLUGIN-1936](https://cdap.atlassian.net/browse/PLUGIN-1936)

**Issue** : OutOfMemory (OOM) Errors seen in the ServiceNow Connector frequently when transfering large number of records

**RCA**: The entire response is converted into string and the JSON is parsed in memory leading to OOM issues. 

**Proposed Fix:**  Read the records incrementally i.e. one by one in a streaming manner. 

**Changes** : 
- Refactored the existing method: `prepareResponse` :in the `RESTAPIResponse` class to return a reusable InputStream in the `RESTAPIResponse` object. 
- Added `openNextPage` to initialise the `Gson's` `JsonReader` and read the `result` array in the response and `closeCurrentPage` to close the `JsonReader`
- `nextKeyValue()` : Refactored the existing logic to stream one record at a time.
- Changed the return type of the following methods from Map<String, String> to RESTAPIResponse
   - `fetchData()`
   - `fetchTableRecordsRetryableMode()`
   - `fetchTableRecords()`
   
**Testing**
<img width="1789" height="576" alt="image" src="https://github.com/user-attachments/assets/a48e9b6c-9551-4e0d-98fc-ac35bc6f631c" />




  

[PLUGIN-1936]: https://cdap.atlassian.net/browse/PLUGIN-1936?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ