### PR TITLE
PLUGIN-1940 : Support Array Type

### DIFF
--- a/src/e2e-test/java/io/cdap/plugin/servicenowsink/actions/ServiceNowSinkPropertiesPageActions.java
+++ b/src/e2e-test/java/io/cdap/plugin/servicenowsink/actions/ServiceNowSinkPropertiesPageActions.java
@@ -60,7 +60,7 @@ public class ServiceNowSinkPropertiesPageActions {
         System.getenv("SERVICE_NOW_REST_API_ENDPOINT"),
         System.getenv("SERVICE_NOW_USERNAME"),
         System.getenv("SERVICE_NOW_PASSWORD"),
-        "", "", "", null);
+        "", "", "", null, false);
 
     ServiceNowTableAPIClientImpl tableAPIClient = new ServiceNowTableAPIClientImpl(config.getConnection(), true);
     responseFromServiceNowTable = tableAPIClient.getRecordFromServiceNowTable(tableName, query);

--- a/src/e2e-test/java/io/cdap/plugin/tests/hooks/TestSetupHooks.java
+++ b/src/e2e-test/java/io/cdap/plugin/tests/hooks/TestSetupHooks.java
@@ -59,7 +59,7 @@ public class TestSetupHooks {
         System.getenv("SERVICE_NOW_REST_API_ENDPOINT"),
         System.getenv("SERVICE_NOW_USERNAME"),
         System.getenv("SERVICE_NOW_PASSWORD"),
-        "", "", "", null);
+        "", "", "", null, false);
   }
 
   @Before(order = 2, value = "@SN_PRODUCT_CATALOG_ITEM")

--- a/src/main/java/io/cdap/plugin/servicenow/apiclient/ServiceNowTableAPIClientImpl.java
+++ b/src/main/java/io/cdap/plugin/servicenow/apiclient/ServiceNowTableAPIClientImpl.java
@@ -27,6 +27,7 @@ import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.reflect.TypeToken;
+import com.sun.org.apache.xpath.internal.operations.Bool;
 import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.etl.api.FailureCollector;
 import io.cdap.plugin.servicenow.connector.ServiceNowConnectorConfig;
@@ -291,7 +292,7 @@ public class ServiceNowTableAPIClientImpl extends RestAPIClient {
    */
   public Schema fetchTableSchema(String tableName, SourceValueType valueType)
       throws ServiceNowAPIException {
-    return fetchTableSchema(tableName, getAccessToken(), valueType, schemaType);
+    return fetchTableSchema(tableName, getAccessToken(), valueType, schemaType, false);
   }
 
   private SchemaType getSchemaTypeBasedOnUseConnection(Boolean useConnection) {
@@ -310,10 +311,11 @@ public class ServiceNowTableAPIClientImpl extends RestAPIClient {
    * @param accessToken Access Token to use
    * @param valueType Type of value (Actual/Display)
    * @param schemaType Enum to determine which approach to take to fetch schema.
+   * @param enableNewDataTypes Flag to enable new data types
    * @return schema for given ServiceNow table
    */
   public Schema fetchTableSchema(String tableName, String accessToken, SourceValueType valueType,
-                                 SchemaType schemaType)
+                                 SchemaType schemaType, Boolean enableNewDataTypes)
       throws ServiceNowAPIException {
     ServiceNowTableAPIRequestBuilder requestBuilder = new ServiceNowTableAPIRequestBuilder(
       this.conf.getRestApiEndpoint(), tableName, true, schemaType)
@@ -325,7 +327,7 @@ public class ServiceNowTableAPIClientImpl extends RestAPIClient {
     List<ServiceNowColumn> columns = new ArrayList<>();
 
     if (schemaType == SchemaType.METADATA_API_BASED) {
-      return prepareSchemaWithMetadataAPI(restAPIResponse, columns, tableName, valueType);
+      return prepareSchemaWithMetadataAPI(restAPIResponse, columns, tableName, valueType, enableNewDataTypes);
     } else if (schemaType == SchemaType.SCHEMA_API_BASED) {
       return prepareSchemaWithSchemaAPI(restAPIResponse, columns, tableName);
     } else {
@@ -362,7 +364,7 @@ public class ServiceNowTableAPIClientImpl extends RestAPIClient {
     for (SchemaAPISchemaField field : schemaAPISchemaResponse.getResult()) {
       columns.add(new ServiceNowColumn(field.getName(), field.getInternalType()));
     }
-    return SchemaBuilder.constructSchema(tableName, columns);
+    return SchemaBuilder.constructSchema(tableName, columns, false);
   }
 
   /**
@@ -384,8 +386,7 @@ public class ServiceNowTableAPIClientImpl extends RestAPIClient {
    * @throws RuntimeException if the response does not contain valid column information.
    */
   private Schema prepareSchemaWithMetadataAPI(RestAPIResponse restAPIResponse, List<ServiceNowColumn> columns,
-                                              String tableName, SourceValueType valueType) throws
-    ServiceNowAPIException {
+    String tableName, SourceValueType valueType, Boolean enableNewDataTypes) throws ServiceNowAPIException {
     MetadataAPISchemaResponse metadataAPISchemaResponse = parseSchemaResponse(restAPIResponse.getResponseBody());
 
     if (metadataAPISchemaResponse.getResult() == null || metadataAPISchemaResponse.getResult().getColumns() == null ||
@@ -410,7 +411,7 @@ public class ServiceNowTableAPIClientImpl extends RestAPIClient {
         columns.add(new ServiceNowColumn(field.getName(), field.getInternalType()));
       }
     }
-    return SchemaBuilder.constructSchema(tableName, columns);
+    return SchemaBuilder.constructSchema(tableName, columns, enableNewDataTypes);
   }
 
   /**
@@ -552,7 +553,7 @@ public class ServiceNowTableAPIClientImpl extends RestAPIClient {
       for (String key : firstRecord.keySet()) {
         columns.add(new ServiceNowColumn(key, "string"));
       }
-      return SchemaBuilder.constructSchema(tableName, columns);
+      return SchemaBuilder.constructSchema(tableName, columns, false);
     }
     return null;
   }

--- a/src/main/java/io/cdap/plugin/servicenow/connector/ServiceNowConnector.java
+++ b/src/main/java/io/cdap/plugin/servicenow/connector/ServiceNowConnector.java
@@ -193,7 +193,7 @@ public class ServiceNowConnector implements DirectConnector {
         StructuredRecord.Builder recordBuilder = StructuredRecord.builder(schema);
         for (Schema.Field field : tableFields) {
           String fieldName = field.getName();
-          ServiceNowRecordConverter.convertToValue(fieldName, field.getSchema(), result.get(i), recordBuilder);
+          ServiceNowRecordConverter.convertToValue(fieldName, field.getSchema(), result.get(i), recordBuilder, false);
         }
         StructuredRecord structuredRecord = recordBuilder.build();
         recordList.add(structuredRecord);

--- a/src/main/java/io/cdap/plugin/servicenow/connector/ServiceNowRecordConverter.java
+++ b/src/main/java/io/cdap/plugin/servicenow/connector/ServiceNowRecordConverter.java
@@ -32,6 +32,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * Utility class for converting the record from ServiceNow data type to CDAP schema data types
@@ -83,7 +84,7 @@ public class ServiceNowRecordConverter {
     ));
 
   public static void convertToValue(String fieldName, Schema fieldSchema, Map<String, String> record,
-                                    StructuredRecord.Builder recordBuilder) {
+    StructuredRecord.Builder recordBuilder, Boolean enableNewDataTypes) {
     String fieldValue = record.get(fieldName);
     if (fieldValue == null || fieldValue.isEmpty()) {
       // Set 'null' value as it is
@@ -128,11 +129,24 @@ public class ServiceNowRecordConverter {
       case BOOLEAN:
         recordBuilder.set(fieldName, convertToBooleanValue(fieldValue));
         return;
+      case ARRAY:
+        recordBuilder.set(fieldName, enableNewDataTypes.equals(Boolean.TRUE) ? convertToList(fieldValue) : fieldValue);
+        return;
       default:
         throw new IllegalStateException(
           String.format("Record type '%s' is not supported for field '%s'", fieldType.name(), fieldName));
     }
 
+  }
+
+  public static List<String> convertToList(String fieldValue) {
+    if (fieldValue.trim().isEmpty()) {
+      return Collections.emptyList();
+    }
+    return Arrays.stream(fieldValue.split(","))
+      .map(String::trim)
+      .filter(s -> !s.isEmpty())
+      .collect(Collectors.toList());
   }
 
   @VisibleForTesting

--- a/src/main/java/io/cdap/plugin/servicenow/source/ServiceNowBaseSourceConfig.java
+++ b/src/main/java/io/cdap/plugin/servicenow/source/ServiceNowBaseSourceConfig.java
@@ -74,6 +74,11 @@ public class ServiceNowBaseSourceConfig extends ServiceNowBaseConfig {
   @Nullable
   @Description("The number of records to fetch from ServiceNow. Default is 5000.")
   private Integer pageSize;
+  
+  @Name(ServiceNowConstants.PROPERTY_ENABLE_NEW_DATA_TYPES)
+  @Nullable
+  @Description("Enable support for new data types such as array (glide_list) ")
+  private Boolean enableNewDataTypes;
 
   /**
    * Constructor for ServiceNowSourceConfig object.
@@ -92,7 +97,8 @@ public class ServiceNowBaseSourceConfig extends ServiceNowBaseConfig {
    */
   public ServiceNowBaseSourceConfig(String referenceName, String clientId, String clientSecret, String restApiEndpoint,
                                     String user, String password, String tableNameField, String valueType,
-                                    @Nullable String startDate, @Nullable String endDate, Integer pageSize) {
+                                    @Nullable String startDate, @Nullable String endDate, Integer pageSize,
+                                    Boolean enableNewDataTypes) {
     super(clientId, clientSecret, restApiEndpoint, user, password);
     this.referenceName = referenceName;
     this.tableNameField = tableNameField;
@@ -100,6 +106,7 @@ public class ServiceNowBaseSourceConfig extends ServiceNowBaseConfig {
     this.startDate = startDate;
     this.endDate = endDate;
     this.pageSize = pageSize;
+    this.enableNewDataTypes = enableNewDataTypes;
   }
 
   public String getReferenceName() {
@@ -122,6 +129,10 @@ public class ServiceNowBaseSourceConfig extends ServiceNowBaseConfig {
 
   public Integer getPageSize() {
     return pageSize == null ? ServiceNowConstants.PAGE_SIZE : pageSize;
+  }
+
+  public Boolean getEnableNewDataTypes() {
+    return enableNewDataTypes == null ? Boolean.FALSE : enableNewDataTypes;
   }
 
   /**

--- a/src/main/java/io/cdap/plugin/servicenow/source/ServiceNowMultiRecordReader.java
+++ b/src/main/java/io/cdap/plugin/servicenow/source/ServiceNowMultiRecordReader.java
@@ -36,6 +36,7 @@ public class ServiceNowMultiRecordReader extends ServiceNowBaseRecordReader {
 
   private final ServiceNowMultiSourceConfig multiSourcePluginConf;
   private ServiceNowTableAPIClientImpl restApi;
+  private Boolean enableNewDataTypes;
 
   ServiceNowMultiRecordReader(ServiceNowMultiSourceConfig multiSourcePluginConf) {
     super();
@@ -81,8 +82,8 @@ public class ServiceNowMultiRecordReader extends ServiceNowBaseRecordReader {
     try {
       for (Schema.Field field : tableFields) {
         String fieldName = field.getName();
-        ServiceNowRecordConverter.convertToValue(fieldName, field.getSchema(), row,
-                                                 recordBuilder);
+        ServiceNowRecordConverter.convertToValue(fieldName, field.getSchema(), row, recordBuilder,
+          multiSourcePluginConf.getEnableNewDataTypes());
       }
     } catch (Exception e) {
       throw new IOException("Error decoding row from table " + tableName, e);

--- a/src/main/java/io/cdap/plugin/servicenow/source/ServiceNowMultiSourceConfig.java
+++ b/src/main/java/io/cdap/plugin/servicenow/source/ServiceNowMultiSourceConfig.java
@@ -55,9 +55,9 @@ public class ServiceNowMultiSourceConfig extends ServiceNowBaseSourceConfig {
   public ServiceNowMultiSourceConfig(String referenceName, String clientId, String clientSecret, String restApiEndpoint,
                                      String user, String password, String tableNameField, String valueType,
                                      @Nullable String startDate, @Nullable String endDate, Integer pageSize,
-                                     String tableNames) {
+                                     String tableNames, Boolean enableNewDataTypes) {
     super(referenceName, clientId, clientSecret, restApiEndpoint, user, password, tableNameField, valueType, startDate,
-          endDate, pageSize);
+          endDate, pageSize, enableNewDataTypes);
     this.tableNames = tableNames;
   }
 

--- a/src/main/java/io/cdap/plugin/servicenow/source/ServiceNowRecordReader.java
+++ b/src/main/java/io/cdap/plugin/servicenow/source/ServiceNowRecordReader.java
@@ -38,6 +38,7 @@ public class ServiceNowRecordReader extends ServiceNowBaseRecordReader {
   private static final Logger LOG = LoggerFactory.getLogger(ServiceNowRecordReader.class);
   private final ServiceNowSourceConfig pluginConf;
   private ServiceNowTableAPIClientImpl restApi;
+  private Boolean enableNewDataTypes;
 
   public ServiceNowRecordReader(ServiceNowSourceConfig pluginConf) {
     super();
@@ -94,7 +95,8 @@ public class ServiceNowRecordReader extends ServiceNowBaseRecordReader {
     try {
       for (Schema.Field field : tableFields) {
         String fieldName = field.getName();
-        ServiceNowRecordConverter.convertToValue(fieldName, field.getSchema(), row, recordBuilder);
+        ServiceNowRecordConverter.convertToValue(fieldName, field.getSchema(), row, recordBuilder,
+          pluginConf.getEnableNewDataTypes());
       }
     } catch (Exception e) {
       LOG.error("Error decoding row from table " + tableName, e);

--- a/src/main/java/io/cdap/plugin/servicenow/source/ServiceNowSourceConfig.java
+++ b/src/main/java/io/cdap/plugin/servicenow/source/ServiceNowSourceConfig.java
@@ -79,9 +79,9 @@ public class ServiceNowSourceConfig extends ServiceNowBaseSourceConfig {
                                 @Nullable String tableNameField, @Nullable String tableName, String clientId,
                                 String clientSecret, String restApiEndpoint, String user, String password,
                                 String valueType, @Nullable String startDate, @Nullable String endDate,
-                                Integer pageSize) {
+                                Integer pageSize, Boolean enableNewDataTypes) {
     super(referenceName, clientId, clientSecret, restApiEndpoint, user, password, tableNameField, valueType, startDate,
-          endDate, pageSize);
+          endDate, pageSize, enableNewDataTypes);
     this.referenceName = referenceName;
     this.queryMode = queryMode;
     this.applicationName = applicationName;

--- a/src/main/java/io/cdap/plugin/servicenow/util/SchemaBuilder.java
+++ b/src/main/java/io/cdap/plugin/servicenow/util/SchemaBuilder.java
@@ -34,27 +34,27 @@ public class SchemaBuilder {
    * @param columns   The list of ServiceNowColumn objects that will be added as Schema.Field
    * @return The instance of Schema object
    */
-  public static Schema constructSchema(String tableName, List<ServiceNowColumn> columns) {
+  public static Schema constructSchema(String tableName, List<ServiceNowColumn> columns, boolean enableNewDataTypes) {
     SchemaBuilder schemaBuilder = new SchemaBuilder();
-    List<Schema.Field> fields = schemaBuilder.constructSchemaFields(columns);
+    List<Schema.Field> fields = schemaBuilder.constructSchemaFields(columns, enableNewDataTypes);
 
     return Schema.recordOf(tableName, fields);
   }
 
-  private List<Schema.Field> constructSchemaFields(List<ServiceNowColumn> columns) {
+  private List<Schema.Field> constructSchemaFields(List<ServiceNowColumn> columns, Boolean enableNewDataTypes) {
     return columns.stream()
-      .map(o -> transformToField(o))
+      .map(o -> transformToField(o, enableNewDataTypes))
       .filter(Objects::nonNull)
       .collect(Collectors.toList());
   }
 
-  private Schema.Field transformToField(ServiceNowColumn column) {
+  private Schema.Field transformToField(ServiceNowColumn column, Boolean enableNewDataTypes) {
     String name = column.getFieldName();
     if (Strings.isNullOrEmpty(name)) {
       return null;
     }
 
-    Schema schema = createSchema(column);
+    Schema schema = createSchema(column, enableNewDataTypes);
     if (schema == null) {
       return null;
     }
@@ -64,7 +64,7 @@ public class SchemaBuilder {
       : Schema.Field.of(name, Schema.nullableOf(schema));
   }
 
-  private Schema createSchema(ServiceNowColumn column) {
+  private Schema createSchema(ServiceNowColumn column, Boolean enableNewDataTypes) {
     switch (column.getTypeName().toLowerCase()) {
       case "decimal":
         return Schema.of(Schema.Type.DOUBLE);
@@ -78,6 +78,9 @@ public class SchemaBuilder {
         return Schema.of(Schema.LogicalType.DATETIME);
       case "glide_time":
         return Schema.of(Schema.LogicalType.TIME_MICROS);
+      case "glide_list":
+        return enableNewDataTypes.equals(Boolean.TRUE) ? Schema.arrayOf(Schema.of(Schema.Type.STRING)) :
+          Schema.of(Schema.Type.STRING);
       case "reference":
       case "currency":
       case "sys_class_name":

--- a/src/main/java/io/cdap/plugin/servicenow/util/ServiceNowConstants.java
+++ b/src/main/java/io/cdap/plugin/servicenow/util/ServiceNowConstants.java
@@ -52,6 +52,11 @@ public interface ServiceNowConstants {
   String PROPERTY_TABLE_NAME = "tableName";
 
   /**
+    * Configuration property name used to enable new data types.
+   */
+  String PROPERTY_ENABLE_NEW_DATA_TYPES = "enableNewDataTypes";
+
+  /**
    * Configuration property name used to specify table names.
    */
   String PROPERTY_TABLE_NAMES = "tableNames";

--- a/src/test/java/io/cdap/plugin/servicenow/apiclient/ServiceNowTableAPIClientImplTest.java
+++ b/src/test/java/io/cdap/plugin/servicenow/apiclient/ServiceNowTableAPIClientImplTest.java
@@ -107,7 +107,7 @@ public class ServiceNowTableAPIClientImplTest {
     RestAPIResponse mockResponse = new RestAPIResponse(Collections.emptyMap(), jsonResponse, null);
     Mockito.doReturn(mockResponse).when(implSpy).executeGetWithRetries(Mockito.any());
     Schema schema = implSpy.fetchTableSchema("sys_user", "dummy-access-token",
-                                             SourceValueType.SHOW_ACTUAL_VALUE, SchemaType.SCHEMA_API_BASED);
+      SourceValueType.SHOW_ACTUAL_VALUE, SchemaType.SCHEMA_API_BASED, false);
     Assert.assertNotNull(schema);
     Assert.assertEquals("record", schema.getDisplayName());
     Assert.assertEquals(2, schema.getFields().size());
@@ -140,7 +140,7 @@ public class ServiceNowTableAPIClientImplTest {
     Mockito.doReturn(mockResponse).when(implSpy).executeGetWithRetries(Mockito.any());
 
     Schema schema = implSpy.fetchTableSchema("u_custom_table",
-      "dummy-access-token", SourceValueType.SHOW_ACTUAL_VALUE, SchemaType.METADATA_API_BASED);
+      "dummy-access-token", SourceValueType.SHOW_ACTUAL_VALUE, SchemaType.METADATA_API_BASED, false);
 
     Assert.assertNotNull(schema);
     Assert.assertEquals("record", schema.getDisplayName());
@@ -178,7 +178,7 @@ public class ServiceNowTableAPIClientImplTest {
     RestAPIResponse mockResponse = new RestAPIResponse(Collections.emptyMap(), jsonResponse, null);
     Mockito.doReturn(mockResponse).when(implSpy).executeGetWithRetries(Mockito.any());
     Schema schema = implSpy.fetchTableSchema("sys_user", "dummy-access-token",
-      SourceValueType.SHOW_DISPLAY_VALUE, SchemaType.SCHEMA_API_BASED);
+      SourceValueType.SHOW_DISPLAY_VALUE, SchemaType.SCHEMA_API_BASED, false);
     Assert.assertNotNull(schema);
     Assert.assertEquals("record", schema.getDisplayName());
     Assert.assertEquals(2, schema.getFields().size());
@@ -215,7 +215,7 @@ public class ServiceNowTableAPIClientImplTest {
     RestAPIResponse mockResponse = new RestAPIResponse(Collections.emptyMap(), jsonResponse, null);
     Mockito.doReturn(mockResponse).when(implSpy).executeGetWithRetries(Mockito.any());
     Schema schema = implSpy.fetchTableSchema("incident", "dummy-access-token",
-                                             SourceValueType.SHOW_DISPLAY_VALUE, SchemaType.METADATA_API_BASED);
+      SourceValueType.SHOW_DISPLAY_VALUE, SchemaType.METADATA_API_BASED, false);
     Assert.assertNotNull(schema);
     Assert.assertEquals("record", schema.getDisplayName());
     Assert.assertEquals(2, schema.getFields().size());
@@ -223,5 +223,81 @@ public class ServiceNowTableAPIClientImplTest {
                         schema.getField("business_stc").getSchema().getUnionSchemas().get(0).getType());
     Assert.assertEquals(Schema.Type.STRING,
                         schema.getField("calendar_stc").getSchema().getUnionSchemas().get(0).getType());
+  }
+
+  @Test
+  public void testFetchTableSchema_WithGlide_ListType_ParseAsArray() throws Exception {
+    ServiceNowConnectorConfig mockConfig = Mockito.mock(ServiceNowConnectorConfig.class);
+    ServiceNowTableAPIClientImpl impl = new ServiceNowTableAPIClientImpl(mockConfig, true);
+    ServiceNowTableAPIClientImpl implSpy = Mockito.spy(impl);
+    String jsonResponse = "{\n" +
+      "  \"result\": {\n" +
+      "    \"columns\": {\n" +
+      "      \"u_glide_array2\": {\n" +
+      "         \"label\": \"glide_array2\",\n" +
+      "         \"type\": \"glide_static_list\",\n" +
+      "         \"base_type\": \"string\",\n" +
+      "         \"name\": \"u_glide_array2\",\n" +
+      "         \"internal_type\": \"glide_list\"\n" +
+      "       },\n" +
+      "         \"u_glide_array3\": {\n" +
+      "         \"label\": \"glide_array3\",\n" +
+      "         \"type\": \"glide_static_list\",\n" +
+      "         \"base_type\": \"string\",\n" +
+      "         \"name\": \"u_glide_array3\",\n" +
+      "         \"internal_type\": \"glide_list\"\n" +
+      "       }\n" +
+      "    }\n" +
+      "  }\n" +
+      "}";
+    RestAPIResponse mockResponse = new RestAPIResponse(Collections.emptyMap(), jsonResponse, null);
+    Mockito.doReturn(mockResponse).when(implSpy).executeGetWithRetries(Mockito.any());
+    Schema schema = implSpy.fetchTableSchema("u_custom_13", "dummy-access-token",
+      SourceValueType.SHOW_ACTUAL_VALUE, SchemaType.METADATA_API_BASED, true);
+    Assert.assertNotNull(schema);
+    Assert.assertEquals("record", schema.getDisplayName());
+    Assert.assertEquals(2, schema.getFields().size());
+    Assert.assertEquals(Schema.Type.ARRAY,
+                        schema.getField("u_glide_array2").getSchema().getUnionSchemas().get(0).getType());
+    Assert.assertEquals(Schema.Type.ARRAY,
+                        schema.getField("u_glide_array3").getSchema().getUnionSchemas().get(0).getType());
+  }
+
+  @Test
+  public void testFetchTableSchema_WithGlide_ListType_ParseAsString() throws Exception {
+    ServiceNowConnectorConfig mockConfig = Mockito.mock(ServiceNowConnectorConfig.class);
+    ServiceNowTableAPIClientImpl impl = new ServiceNowTableAPIClientImpl(mockConfig, true);
+    ServiceNowTableAPIClientImpl implSpy = Mockito.spy(impl);
+    String jsonResponse = "{\n" +
+      "  \"result\": {\n" +
+      "    \"columns\": {\n" +
+      "      \"u_glide_array2\": {\n" +
+      "         \"label\": \"glide_array2\",\n" +
+      "         \"type\": \"glide_static_list\",\n" +
+      "         \"base_type\": \"string\",\n" +
+      "         \"name\": \"u_glide_array2\",\n" +
+      "         \"internal_type\": \"glide_list\"\n" +
+      "       },\n" +
+      "         \"u_glide_array3\": {\n" +
+      "         \"label\": \"glide_array3\",\n" +
+      "         \"type\": \"glide_static_list\",\n" +
+      "         \"base_type\": \"string\",\n" +
+      "         \"name\": \"u_glide_array3\",\n" +
+      "         \"internal_type\": \"glide_list\"\n" +
+      "       }\n" +
+      "    }\n" +
+      "  }\n" +
+      "}";
+    RestAPIResponse mockResponse = new RestAPIResponse(Collections.emptyMap(), jsonResponse, null);
+    Mockito.doReturn(mockResponse).when(implSpy).executeGetWithRetries(Mockito.any());
+    Schema schema = implSpy.fetchTableSchema("u_custom_13", "dummy-access-token",
+     SourceValueType.SHOW_ACTUAL_VALUE, SchemaType.METADATA_API_BASED, false);
+    Assert.assertNotNull(schema);
+    Assert.assertEquals("record", schema.getDisplayName());
+    Assert.assertEquals(2, schema.getFields().size());
+    Assert.assertEquals(Schema.Type.STRING,
+                        schema.getField("u_glide_array2").getSchema().getUnionSchemas().get(0).getType());
+    Assert.assertEquals(Schema.Type.STRING,
+                        schema.getField("u_glide_array3").getSchema().getUnionSchemas().get(0).getType());
   }
 }

--- a/src/test/java/io/cdap/plugin/servicenow/sink/ServiceNowSinkConfigTest.java
+++ b/src/test/java/io/cdap/plugin/servicenow/sink/ServiceNowSinkConfigTest.java
@@ -297,7 +297,7 @@ public class ServiceNowSinkConfigTest {
       "    ]\n" +
       "}";
     MetadataAPISchemaField schemaField = new MetadataAPISchemaField("Class", "sys_class_name",
-                                                                    "sys_class_name", "sys_class_name");
+      "sys_class_name", "sys_class_name");
     Map<String, MetadataAPISchemaField> columns = new HashMap<>();
     columns.put("sys_class_name", schemaField);
     MetadataAPISchemaResult schemaResult = new MetadataAPISchemaResult(columns);

--- a/src/test/java/io/cdap/plugin/servicenow/source/ServiceNowMultiRecordReaderTest.java
+++ b/src/test/java/io/cdap/plugin/servicenow/source/ServiceNowMultiRecordReaderTest.java
@@ -24,7 +24,6 @@ import io.cdap.plugin.servicenow.apiclient.ServiceNowAPIException;
 import io.cdap.plugin.servicenow.apiclient.ServiceNowTableAPIClientImpl;
 import io.cdap.plugin.servicenow.apiclient.ServiceNowTableDataResponse;
 import io.cdap.plugin.servicenow.connector.ServiceNowRecordConverter;
-import io.cdap.plugin.servicenow.util.ServiceNowConstants;
 import org.apache.oltu.oauth2.common.exception.OAuthProblemException;
 import org.apache.oltu.oauth2.common.exception.OAuthSystemException;
 import org.junit.Assert;
@@ -97,7 +96,7 @@ public class ServiceNowMultiRecordReaderTest {
     StructuredRecord.Builder recordBuilder = StructuredRecord.builder(fieldSchema);
     Map<String, String> map = new HashMap<>();
     map.put("TimeField", "value");
-    ServiceNowRecordConverter.convertToValue("TimeField", fieldSchema, map, recordBuilder);
+    ServiceNowRecordConverter.convertToValue("TimeField", fieldSchema, map, recordBuilder, false);
   }
 
   @Test
@@ -171,6 +170,7 @@ public class ServiceNowMultiRecordReaderTest {
             .setStartDate("2021-01-01")
             .setEndDate("2022-02-18")
             .setPageSize(10)
+            .setEnableNewDataTypes(false)
             .setTableNameField("tablename")
             .buildMultiSource();
 

--- a/src/test/java/io/cdap/plugin/servicenow/source/ServiceNowMultiSourceConfigTest.java
+++ b/src/test/java/io/cdap/plugin/servicenow/source/ServiceNowMultiSourceConfigTest.java
@@ -52,7 +52,7 @@ public class ServiceNowMultiSourceConfigTest {
     serviceNowMultiSourceConfig = new ServiceNowMultiSourceConfig("referenceName", "client_id",
       "client_secret", "https://example.com", "user", "password",
       "tablename", "Actual", "2021-12-30", "2021-12-31", 10,
-      "sys_user");
+      "sys_user", false);
     Assert.assertEquals("sys_user", serviceNowMultiSourceConfig.getTableNames());
     Assert.assertEquals("Actual", serviceNowMultiSourceConfig.getValueType().getValueType());
     Assert.assertEquals("2021-12-30", serviceNowMultiSourceConfig.getStartDate());
@@ -417,7 +417,7 @@ public class ServiceNowMultiSourceConfigTest {
       "Reference Name", "42", "client_secret",
       "https://config.us-east-2.amazonaws.com", "User", "password",
       "tablename", "Actual", "2020-03-01", "2020-03-01", 10,
-      ",");
+      ",", false);
     serviceNowMultiSourceConfig.validateTableNames(new MockFailureCollector("Stage Name"));
     Assert.assertEquals("42", serviceNowMultiSourceConfig.getConnection().getClientId());
     Assert.assertEquals("tablename", serviceNowMultiSourceConfig.tableNameField);
@@ -437,7 +437,7 @@ public class ServiceNowMultiSourceConfigTest {
     ServiceNowMultiSourceConfig serviceNowMultiSourceConfig = new ServiceNowMultiSourceConfig(
       "Reference Name", "Table Name Field", "42", "Client Secret",
       "https://config.us-east-2.amazonaws.com", "User", "password", "42",
-      "2020-03-01", "2020-03-01", 10, "");
+      "2020-03-01", "2020-03-01", 10, "", false);
     MockFailureCollector mockFailureCollector = new MockFailureCollector("Stage Name");
     serviceNowMultiSourceConfig.validateTableNames(mockFailureCollector);
     List<ValidationFailure> validationFailures = mockFailureCollector.getValidationFailures();

--- a/src/test/java/io/cdap/plugin/servicenow/source/ServiceNowRecordReaderTest.java
+++ b/src/test/java/io/cdap/plugin/servicenow/source/ServiceNowRecordReaderTest.java
@@ -77,6 +77,7 @@ public class ServiceNowRecordReaderTest {
       .setStartDate("2021-12-30")
       .setEndDate("2021-12-31")
       .setPageSize(10)
+      .setEnableNewDataTypes(false)
       .setTableNameField("tablename")
       .build();
 
@@ -103,7 +104,8 @@ public class ServiceNowRecordReaderTest {
                                                                                "password",
                                                                                "Actual",
                                                                                "2021-12-30",
-                                                                               "2021-12-31", 10);
+                                                                               "2021-12-31", 10,
+                                                                               false);
 
     serviceNowRecordReader.close();
     Assert.assertEquals(0, serviceNowRecordReader.pos);
@@ -131,7 +133,7 @@ public class ServiceNowRecordReaderTest {
     Map<String, String> map = new HashMap<>();
     map.put("TimeField", "value");
     thrown.expect(IllegalStateException.class);
-    ServiceNowRecordConverter.convertToValue("TimeField", fieldSchema, map, recordBuilder);
+    ServiceNowRecordConverter.convertToValue("TimeField", fieldSchema, map, recordBuilder, false);
   }
 
   @Test
@@ -159,7 +161,7 @@ public class ServiceNowRecordReaderTest {
 
       StructuredRecord.Builder recordBuilder = StructuredRecord.builder(recordSchema);
       try {
-        ServiceNowRecordConverter.convertToValue("DateTimeField", fieldSchema, inputMap, recordBuilder);
+        ServiceNowRecordConverter.convertToValue("DateTimeField", fieldSchema, inputMap, recordBuilder, false);
         StructuredRecord record = recordBuilder.build();
         Assert.assertNotNull("Parsed datetime should not be null for input: " + value,
             record.get("DateTimeField"));
@@ -190,7 +192,7 @@ public class ServiceNowRecordReaderTest {
 
       StructuredRecord.Builder recordBuilder = StructuredRecord.builder(recordSchema);
       try {
-        ServiceNowRecordConverter.convertToValue("DateField", fieldSchema, inputMap, recordBuilder);
+        ServiceNowRecordConverter.convertToValue("DateField", fieldSchema, inputMap, recordBuilder, false);
         StructuredRecord record = recordBuilder.build();
         Assert.assertNotNull("Parsed date should not be null for input: " + value,
             record.get("DateField"));
@@ -219,7 +221,7 @@ public class ServiceNowRecordReaderTest {
 
       StructuredRecord.Builder recordBuilder = StructuredRecord.builder(recordSchema);
       try {
-        ServiceNowRecordConverter.convertToValue("TimeField", fieldSchema, inputMap, recordBuilder);
+        ServiceNowRecordConverter.convertToValue("TimeField", fieldSchema, inputMap, recordBuilder, false);
         StructuredRecord record = recordBuilder.build();
         Assert.assertNotNull("Parsed date should not be null for input: " + value,
             record.get("TimeField"));
@@ -227,6 +229,36 @@ public class ServiceNowRecordReaderTest {
         Assert.fail("Failed to parse valid date format: " + value + " - " + e.getMessage());
       }
     }
+  }
+
+  @Test
+  public void testConvertToValue_WithArrayFieldType_ParseAsString() {
+    Schema recordSchema = Schema.recordOf(
+      "record",
+      Schema.Field.of("ArrayField", Schema.arrayOf(Schema.of(Schema.Type.STRING))
+    ));
+    Schema fieldSchema = recordSchema.getField("ArrayField").getSchema();
+    Map<String, String> inputMap = new HashMap<>();
+    inputMap.put("ArrayField", "\"service_sys_id_1_1\",\"service_sys_id_2_1\"");
+    StructuredRecord.Builder recordBuilder = StructuredRecord.builder(recordSchema);
+    ServiceNowRecordConverter.convertToValue("ArrayField", fieldSchema, inputMap, recordBuilder, false);
+    StructuredRecord record = recordBuilder.build();
+    Assert.assertEquals(inputMap.get("ArrayField"), record.get("ArrayField"));
+  }
+
+  @Test
+  public void testConvertToValue_WithArrayFieldType_ParseAsArray() {
+    Schema recordSchema = Schema.recordOf(
+      "record",
+      Schema.Field.of("ArrayField", Schema.arrayOf(Schema.of(Schema.Type.STRING))
+      ));
+    Schema fieldSchema = recordSchema.getField("ArrayField").getSchema();
+    Map<String, String> inputMap = new HashMap<>();
+    inputMap.put("ArrayField", "\"service_sys_id_1_1\",\"service_sys_id_2_1\"");
+    StructuredRecord.Builder recordBuilder = StructuredRecord.builder(recordSchema);
+    ServiceNowRecordConverter.convertToValue("ArrayField", fieldSchema, inputMap, recordBuilder, true);
+    StructuredRecord record = recordBuilder.build();
+    Assert.assertEquals(Arrays.asList(inputMap.get("ArrayField").split(",")), record.get("ArrayField"));
   }
 
   @Test

--- a/src/test/java/io/cdap/plugin/servicenow/source/ServiceNowSourceConfigHelper.java
+++ b/src/test/java/io/cdap/plugin/servicenow/source/ServiceNowSourceConfigHelper.java
@@ -59,7 +59,7 @@ public class ServiceNowSourceConfigHelper {
     private String startDate = "";
     private String endDate = "";
     private Integer pageSize = 5000;
-
+    private Boolean enableNewDataTypes = false;
 
     public ConfigBuilder setReferenceName(String referenceName) {
       this.referenceName = referenceName;
@@ -136,14 +136,20 @@ public class ServiceNowSourceConfigHelper {
       return this;
     }
 
+    public ConfigBuilder setEnableNewDataTypes(Boolean enableNewDataTypes) {
+      this.enableNewDataTypes = enableNewDataTypes;
+      return this;
+    }
+
     public ServiceNowSourceConfig build() {
       return new ServiceNowSourceConfig(referenceName, queryMode, applicationName, tableNameField, tableName,
-        clientId, clientSecret, restApiEndpoint, user, password, valueType, startDate, endDate, pageSize);
+        clientId, clientSecret, restApiEndpoint, user, password, valueType, startDate, endDate, pageSize,
+          enableNewDataTypes);
     }
 
     public ServiceNowMultiSourceConfig buildMultiSource() {
       return new ServiceNowMultiSourceConfig(referenceName, clientId, clientSecret, restApiEndpoint, user, password,
-        tableNameField, valueType, startDate, endDate, pageSize, tableNames);
+        tableNameField, valueType, startDate, endDate, pageSize, tableNames, enableNewDataTypes);
     }
 
 

--- a/widgets/ServiceNow-batchsource.json
+++ b/widgets/ServiceNow-batchsource.json
@@ -186,6 +186,22 @@
             "placeholder": "Number of records to fetch from ServiceNow",
             "default": 5000
           }
+        },
+        {
+          "widget-type": "hidden",
+          "label": "Enable New Data Types",
+          "name": "enableNewDataTypes",
+          "widget-attributes": {
+            "on": {
+              "value": "true",
+              "label": "YES"
+            },
+            "off": {
+              "value": "false",
+              "label": "NO"
+            },
+            "default": "false"
+          }
         }
       ]
     }

--- a/widgets/ServiceNowMultiSource-batchsource.json
+++ b/widgets/ServiceNowMultiSource-batchsource.json
@@ -148,6 +148,22 @@
             "placeholder": "The name of the field that holds the table name.",
             "default": "tablename"
           }
+        },
+        {
+          "widget-type": "hidden",
+          "label": "Enable New Data Types",
+          "name": "enableNewDataTypes",
+          "widget-attributes": {
+            "on": {
+              "value": "true",
+              "label": "YES"
+            },
+            "off": {
+              "value": "false",
+              "label": "NO"
+            },
+            "default": "false"
+          }
         }
       ]
     }


### PR DESCRIPTION
[PLUGIN-1940](https://cdap.atlassian.net/browse/PLUGIN-1940)

This change introduces support for mapping ServiceNow `glide_list` fields to BigQuery `ARRAY<STRING>` types in the ServiceNow CDAP plugin.

New Boolean Property [Hidden] added: `enableNewDataTypes` to the Batch Source Plugins. Default: `false`

If this property is true, then the fields with `glide_list` type are mapped to Array of Strings in BigQuery, otherwise, it is mapped to String. This property can be used by the DTS Connector to pass the value for `enableNewDataTypes` flag.

<img width="1792" height="628" alt="image" src="https://github.com/user-attachments/assets/9e687fd5-d65a-4cf1-8e4e-43653995d617" />
<img width="477" height="425" alt="image" src="https://github.com/user-attachments/assets/d6995611-2c98-49a1-907b-70a25b772373" />


<br><br/>

**Note:** There was no option to specify base type while defining List as the type of a column in ServiceNow.

<img width="512" height="217" alt="image" src="https://github.com/user-attachments/assets/463ae0f5-d212-47d1-b5ee-4c462121ba67" />



[PLUGIN-1940]: https://cdap.atlassian.net/browse/PLUGIN-1940?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ