### PR TITLE
[PLUGIN-1944] Support for Filter Queries in Split class.

### DIFF
--- a/src/main/java/io/cdap/plugin/servicenow/apiclient/ServiceNowTableAPIClientImpl.java
+++ b/src/main/java/io/cdap/plugin/servicenow/apiclient/ServiceNowTableAPIClientImpl.java
@@ -122,24 +122,26 @@ public class ServiceNowTableAPIClientImpl extends RestAPIClient {
   }
 
   /**
-   * Fetch the list of records from ServiceNow table.
+   * Fetches a list of records from a ServiceNow table.
    *
-   * @param tableName The ServiceNow table name
-   * @param valueType The value type
-   * @param startDate The start date
-   * @param endDate   The end date
-   * @param offset    The number of records to skip
-   * @param limit     The number of records to be fetched
-   * @return The list of Map; each Map representing a table row
+   * @param tableName The name of the ServiceNow table.
+   * @param valueType The type of value to retrieve (e.g., actual or display).
+   * @param filterQuery An encoded query to filter the records. For example, to filter records created
+   *  between two dates, the query would be: {@code
+   *  sys_created_onBETWEENjavascript:gs.dateGenerate
+   *  ('2023-01-01','start')@javascript:gs.dateGenerate('2023-01-31','end')}
+   * @param offset The number of records to skip from the beginning of the result set.
+   * @param limit The maximum number of records to retrieve.
+   * @return A list of maps, where each map represents a record from the table.
+   * @throws ServiceNowAPIException If an error occurs while fetching the records.
    */
   public List<Map<String, String>> fetchTableRecords(
-      String tableName,
-      SourceValueType valueType,
-      String startDate,
-      String endDate,
-      int offset,
-      int limit)
-      throws ServiceNowAPIException {
+    String tableName,
+    SourceValueType valueType,
+    String filterQuery,
+    int offset,
+    int limit)
+    throws ServiceNowAPIException {
     ServiceNowTableAPIRequestBuilder requestBuilder = new ServiceNowTableAPIRequestBuilder(
       this.conf.getRestApiEndpoint(), tableName, false, schemaType)
       .setExcludeReferenceLink(true)
@@ -150,37 +152,14 @@ public class ServiceNowTableAPIClientImpl extends RestAPIClient {
       requestBuilder.setOffset(offset);
     }
 
-    applyDateRangeToRequest(requestBuilder, startDate, endDate);
+    if (!Util.isNullOrEmpty(filterQuery)) {
+      requestBuilder.setQuery(filterQuery);
+    }
 
     String accessToken = getAccessToken();
     requestBuilder.setAuthHeader(accessToken);
     RestAPIResponse apiResponse = executeGetWithRetries(requestBuilder.build());
     return parseResponseToResultListOfMap(apiResponse.getResponseBody());
-  }
-
-  private void applyDateRangeToRequest(ServiceNowTableAPIRequestBuilder requestBuilder, String startDate,
-                                       String endDate) {
-    String dateRange = generateDateRangeQuery(startDate, endDate);
-    if (!Strings.isNullOrEmpty(dateRange)) {
-      requestBuilder.setQuery(dateRange);
-    }
-  }
-
-  private String generateDateRangeQuery(String startDate, String endDate) {
-    if (Util.isNullOrEmpty(startDate) || Util.isNullOrEmpty(endDate)) {
-      return "";
-    }
-
-    String dateRange = "";
-    try {
-      String createdOnDateRange = String.format(DATE_RANGE_TEMPLATE, FIELD_CREATED_ON, startDate, endDate);
-      String updatedOnDateRange = String.format(DATE_RANGE_TEMPLATE, FIELD_UPDATED_ON, startDate, endDate);
-      dateRange = String.format("%s^OR%s", createdOnDateRange, updatedOnDateRange);
-    } catch (Exception e) {
-      LOG.error("Error in generateDateRangeQuery, hence ignoring the date range", e);
-    }
-
-    return dateRange;
   }
 
   private int getRecordCountFromHeader(RestAPIResponse apiResponse) {
@@ -226,18 +205,16 @@ public class ServiceNowTableAPIClientImpl extends RestAPIClient {
    *
    * @param tableName The ServiceNow table name
    * @param valueType The value type
-   * @param startDate The start date
-   * @param endDate   The end date
    * @param offset    The number of records to skip
    * @param limit     The number of records to be fetched
    * @return The list of Map; each Map representing a table row
    */
   public List<Map<String, String>> fetchTableRecordsRetryableMode(String tableName, SourceValueType valueType,
-                                                                  String startDate, String endDate, int offset,
+                                                                  String filterQuery, int offset,
                                                                   int limit) throws ServiceNowAPIException {
     final List<Map<String, String>> results = new ArrayList<>();
     Callable<Boolean> fetchRecords = () -> {
-      results.addAll(fetchTableRecords(tableName, valueType, startDate, endDate, offset, limit));
+      results.addAll(fetchTableRecords(tableName, valueType, filterQuery, offset, limit));
       return true;
     };
 
@@ -415,15 +392,18 @@ public class ServiceNowTableAPIClientImpl extends RestAPIClient {
   }
 
   /**
-   * Get the total number of records in the table
+   * Gets the total number of records in the table based on the provided date range.
    *
-   * @param tableName ServiceNow table name for which record count is fetched.
-   * @return the table record count
-   * @throws ServiceNowAPIException
+   * @param tableName ServiceNow table name for which record count is fetched
+   * @param startDate Start date to use for filtering records
+   * @param endDate End date to use for filtering records
+   * @return The total number of records
+   * @throws ServiceNowAPIException If an error occurs while fetching the record count
    */
-  public int getTableRecordCount(String tableName)
+  public int getTableRecordCount(String tableName, @Nullable String startDate, @Nullable String endDate)
       throws ServiceNowAPIException {
-    return getTableRecordCount(tableName, getAccessToken());
+      String filterQuery = Util.generateDateRangeQuery(startDate, endDate);
+    return getTableRecordCountUsingFilterQuery(tableName, getAccessToken(), filterQuery);
   }
 
   /**
@@ -434,13 +414,18 @@ public class ServiceNowTableAPIClientImpl extends RestAPIClient {
    * @return the table record count
    * @throws ServiceNowAPIException
    */
-  public int getTableRecordCount(String tableName, String accessToken) throws ServiceNowAPIException {
+  public int getTableRecordCountUsingFilterQuery(String tableName, String accessToken,
+                                 @Nullable String filterQuery)
+          throws ServiceNowAPIException {
     ServiceNowTableAPIRequestBuilder requestBuilder = new ServiceNowTableAPIRequestBuilder(
       this.conf.getRestApiEndpoint(), tableName, false, schemaType)
       .setExcludeReferenceLink(true)
       .setDisplayValue(SourceValueType.SHOW_DISPLAY_VALUE)
       .setLimit(1);
     RestAPIResponse apiResponse = null;
+    if (!Util.isNullOrEmpty(filterQuery)) {
+      requestBuilder.setQuery(filterQuery);
+    }
     requestBuilder.setResponseHeaders(ServiceNowConstants.HEADER_NAME_TOTAL_COUNT);
     requestBuilder.setAuthHeader(accessToken);
     apiResponse = executeGetWithRetries(requestBuilder.build());

--- a/src/main/java/io/cdap/plugin/servicenow/connector/ServiceNowConnector.java
+++ b/src/main/java/io/cdap/plugin/servicenow/connector/ServiceNowConnector.java
@@ -214,7 +214,9 @@ public class ServiceNowConnector implements DirectConnector {
       tableName,
       null,
       SourceValueType.SHOW_DISPLAY_VALUE,
-      true);
+      true,
+      null,
+      null);
     Schema schema = tableInfo.stream().findFirst().isPresent() ? tableInfo.stream().findFirst().get().getSchema() :
       null;
     return schema;

--- a/src/main/java/io/cdap/plugin/servicenow/source/ServiceNowInputFormat.java
+++ b/src/main/java/io/cdap/plugin/servicenow/source/ServiceNowInputFormat.java
@@ -25,6 +25,7 @@ import io.cdap.plugin.servicenow.util.ServiceNowTableInfo;
 import io.cdap.plugin.servicenow.util.SourceApplication;
 import io.cdap.plugin.servicenow.util.SourceQueryMode;
 import io.cdap.plugin.servicenow.util.SourceValueType;
+import io.cdap.plugin.servicenow.util.Util;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.NullWritable;
 import org.apache.hadoop.mapreduce.InputFormat;
@@ -64,7 +65,8 @@ public class ServiceNowInputFormat extends InputFormat<NullWritable, StructuredR
     // return the schema object for each table as ServiceNowTableInfo
     List<ServiceNowTableInfo> tableInfos = fetchTableInfo(mode, conf.getConnection(), conf.getTableName(),
                                                           conf.getApplicationName(), conf.getValueType(),
-                                                          conf.getUseConnection());
+                                                          conf.getUseConnection(), conf.getStartDate(),
+                                                          conf.getEndDate());
     jobConf.setTableInfos(tableInfos);
 
     return tableInfos;
@@ -74,10 +76,11 @@ public class ServiceNowInputFormat extends InputFormat<NullWritable, StructuredR
                                                          @Nullable String tableName,
                                                          @Nullable SourceApplication application,
                                                          @Nullable SourceValueType valueType,
-                                                         @Nullable Boolean useConnection) {
+                                                         @Nullable Boolean useConnection,
+                                                         @Nullable String startdate, @Nullable String enddate) {
     // When mode = Table, fetch details from the table name provided in plugin config
     if (mode == SourceQueryMode.TABLE) {
-      ServiceNowTableInfo tableInfo = getTableMetaData(tableName, conf, valueType, useConnection);
+      ServiceNowTableInfo tableInfo = getTableMetaData(tableName, conf, valueType, useConnection, startdate, enddate);
       return (tableInfo == null) ? Collections.emptyList() : Collections.singletonList(tableInfo);
     }
 
@@ -87,7 +90,7 @@ public class ServiceNowInputFormat extends InputFormat<NullWritable, StructuredR
 
     List<String> tableNames = application.getTableNames();
     for (String table : tableNames) {
-      ServiceNowTableInfo tableInfo = getTableMetaData(table, conf, valueType, useConnection);
+      ServiceNowTableInfo tableInfo = getTableMetaData(table, conf, valueType, useConnection, startdate, enddate);
       if (tableInfo == null) {
         continue;
       }
@@ -100,7 +103,8 @@ public class ServiceNowInputFormat extends InputFormat<NullWritable, StructuredR
   private static ServiceNowTableInfo getTableMetaData(String tableName,
                                                       ServiceNowConnectorConfig conf,
                                                       SourceValueType valueType,
-                                                      @Nullable Boolean useConnection) {
+                                                      @Nullable Boolean useConnection, @Nullable String startdate,
+                                                     @Nullable String enddate) {
     // Call API to fetch first record from the table
     ServiceNowTableAPIClientImpl restApi = new ServiceNowTableAPIClientImpl(conf, useConnection);
 
@@ -111,7 +115,7 @@ public class ServiceNowInputFormat extends InputFormat<NullWritable, StructuredR
       if (schema == null) {
         return null;
       }
-      recordCount = restApi.getTableRecordCount(tableName);
+      recordCount = restApi.getTableRecordCount(tableName, startdate, enddate);
     } catch (ServiceNowAPIException e) {
       throw new RuntimeException(String.format("Error in fetching table metadata due to reason: %s", e.getMessage()),
                                  e);
@@ -132,6 +136,10 @@ public class ServiceNowInputFormat extends InputFormat<NullWritable, StructuredR
    */
   public List<InputSplit> getSplits(Configuration configuration) {
     ServiceNowJobConfiguration jobConfig = new ServiceNowJobConfiguration(configuration);
+    String startdate = jobConfig.getPluginConf().getStartDate();
+    String enddate = jobConfig.getPluginConf().getEndDate();
+    String filterQuery = Util.generateDateRangeQuery(startdate, enddate);
+
     int pageSize = jobConfig.getPluginConf().getPageSize().intValue();
     List<ServiceNowTableInfo> tableInfos = jobConfig.getTableInfos();
     List<InputSplit> resultSplits = new ArrayList<>();
@@ -141,7 +149,7 @@ public class ServiceNowInputFormat extends InputFormat<NullWritable, StructuredR
       int totalRecords = tableInfo.getRecordCount();
       if (totalRecords <= pageSize) {
         // add single split for table and continue
-        resultSplits.add(new ServiceNowInputSplit(tableName, 0));
+        resultSplits.add(new ServiceNowInputSplit(tableName, 0, filterQuery));
         continue;
       }
 
@@ -152,7 +160,7 @@ public class ServiceNowInputFormat extends InputFormat<NullWritable, StructuredR
       int offset = 0;
 
       for (int page = 1; page <= pages; page++) {
-        resultSplits.add(new ServiceNowInputSplit(tableName, offset));
+        resultSplits.add(new ServiceNowInputSplit(tableName, offset, filterQuery));
         offset += pageSize;
       }
     }

--- a/src/main/java/io/cdap/plugin/servicenow/source/ServiceNowInputSplit.java
+++ b/src/main/java/io/cdap/plugin/servicenow/source/ServiceNowInputSplit.java
@@ -29,14 +29,16 @@ import java.io.IOException;
 public class ServiceNowInputSplit extends InputSplit implements Writable {
   private String tableName;
   private int offset;
+  private String filterQuery;
 
   // used by mapreduce
   public ServiceNowInputSplit() {
   }
 
-  public ServiceNowInputSplit(String tableName, int offset) {
+  public ServiceNowInputSplit(String tableName, int offset, String filterQuery) {
     this.tableName = tableName;
     this.offset = offset;
+    this.filterQuery = filterQuery;
   }
 
   public String getTableName() {
@@ -47,16 +49,22 @@ public class ServiceNowInputSplit extends InputSplit implements Writable {
     return offset;
   }
 
+  public String getFilterQuery() {
+    return filterQuery;
+  }
+
   @Override
   public void write(DataOutput dataOutput) throws IOException {
     dataOutput.writeUTF(this.tableName);
     dataOutput.writeInt(this.offset);
+    dataOutput.writeUTF(this.filterQuery);
   }
 
   @Override
   public void readFields(DataInput dataInput) throws IOException {
     this.tableName = dataInput.readUTF();
     this.offset = dataInput.readInt();
+    this.filterQuery = dataInput.readUTF();
   }
 
   @Override

--- a/src/main/java/io/cdap/plugin/servicenow/source/ServiceNowMultiInputFormat.java
+++ b/src/main/java/io/cdap/plugin/servicenow/source/ServiceNowMultiInputFormat.java
@@ -25,6 +25,7 @@ import io.cdap.plugin.servicenow.connector.ServiceNowConnectorConfig;
 import io.cdap.plugin.servicenow.util.ServiceNowConstants;
 import io.cdap.plugin.servicenow.util.ServiceNowTableInfo;
 import io.cdap.plugin.servicenow.util.SourceValueType;
+import io.cdap.plugin.servicenow.util.Util;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.NullWritable;
 import org.apache.hadoop.mapreduce.InputFormat;
@@ -45,6 +46,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import javax.annotation.Nullable;
 
 /**
  * ServiceNow input format.
@@ -68,7 +70,8 @@ public class ServiceNowMultiInputFormat extends InputFormat<NullWritable, Struct
     // Depending on conf value fetch the list of fields for each table and create schema object
     // return the schema object for each table as ServiceNowTableInfo
     Set<ServiceNowTableInfo> tableInfos = fetchTablesInfo(conf.getConnection(), conf.getTableNames(),
-                                                          conf.getUseConnection());
+                                                          conf.getUseConnection(), conf.getStartDate(),
+                                                          conf.getEndDate());
 
     jobConf.setTableInfos(tableInfos.stream().collect(Collectors.toList()));
 
@@ -76,13 +79,14 @@ public class ServiceNowMultiInputFormat extends InputFormat<NullWritable, Struct
   }
 
   static Set<ServiceNowTableInfo> fetchTablesInfo(ServiceNowConnectorConfig conf, String tableNames,
-                                                  Boolean useConnection) {
+                                                  Boolean useConnection, @Nullable String startdate,
+                                                  @Nullable String enddate) {
 
     Set<ServiceNowTableInfo> tablesInfos = new LinkedHashSet<>();
 
     Set<String> tableNameSet = getList(tableNames);
     for (String table : tableNameSet) {
-      ServiceNowTableInfo tableInfo = getTableMetaData(table, conf, useConnection);
+      ServiceNowTableInfo tableInfo = getTableMetaData(table, conf, useConnection, startdate, enddate);
       if (tableInfo == null) {
         continue;
       }
@@ -93,7 +97,8 @@ public class ServiceNowMultiInputFormat extends InputFormat<NullWritable, Struct
   }
 
   private static ServiceNowTableInfo getTableMetaData(String tableName, ServiceNowConnectorConfig conf,
-                                                      Boolean useConnection) {
+                                                      Boolean useConnection, @Nullable String startdate,
+                                                      @Nullable String enddate) {
     // Call API to fetch first record from the table
     ServiceNowTableAPIClientImpl restApi = new ServiceNowTableAPIClientImpl(conf, useConnection);
 
@@ -107,7 +112,7 @@ public class ServiceNowMultiInputFormat extends InputFormat<NullWritable, Struct
       if (schema == null) {
         return null;
       }
-      recordCount = restApi.getTableRecordCount(tableName);
+      recordCount = restApi.getTableRecordCount(tableName, startdate, enddate);
     } catch (ServiceNowAPIException e) {
       throw new RuntimeException(e);
     }
@@ -127,6 +132,11 @@ public class ServiceNowMultiInputFormat extends InputFormat<NullWritable, Struct
   @Override
   public List<InputSplit> getSplits(JobContext jobContext) throws IOException, InterruptedException {
     ServiceNowJobConfiguration jobConfig = new ServiceNowJobConfiguration(jobContext.getConfiguration());
+
+      String startdate = jobConfig.getMultiSourcePluginConf().getStartDate();
+      String enddate = jobConfig.getMultiSourcePluginConf().getEndDate();
+      String filterQuery = Util.generateDateRangeQuery(startdate, enddate);
+
     int pageSize = jobConfig.getPluginConf().getPageSize().intValue();
     List<ServiceNowTableInfo> tableInfos = jobConfig.getTableInfos();
     List<InputSplit> resultSplits = new ArrayList<>();
@@ -142,7 +152,7 @@ public class ServiceNowMultiInputFormat extends InputFormat<NullWritable, Struct
       int offset = 0;
 
       for (int page = 1; page <= pages; page++) {
-        resultSplits.add(new ServiceNowInputSplit(tableName, offset));
+        resultSplits.add(new ServiceNowInputSplit(tableName, offset, filterQuery));
         offset += pageSize;
       }
     }

--- a/src/main/java/io/cdap/plugin/servicenow/source/ServiceNowMultiRecordReader.java
+++ b/src/main/java/io/cdap/plugin/servicenow/source/ServiceNowMultiRecordReader.java
@@ -95,9 +95,8 @@ public class ServiceNowMultiRecordReader extends ServiceNowBaseRecordReader {
   void fetchData() throws ServiceNowAPIException {
     // Get the table data
     results = restApi.fetchTableRecordsRetryableMode(tableName, multiSourcePluginConf.getValueType(),
-                                                     multiSourcePluginConf.getStartDate(),
-                                                     multiSourcePluginConf.getEndDate(), split.getOffset(),
-                                                     multiSourcePluginConf.getPageSize());
+            split.getFilterQuery(), split.getOffset(),
+            multiSourcePluginConf.getPageSize());
 
     iterator = results.iterator();
   }

--- a/src/main/java/io/cdap/plugin/servicenow/source/ServiceNowRecordReader.java
+++ b/src/main/java/io/cdap/plugin/servicenow/source/ServiceNowRecordReader.java
@@ -107,8 +107,8 @@ public class ServiceNowRecordReader extends ServiceNowBaseRecordReader {
 
   private void fetchData() throws ServiceNowAPIException {
     // Get the table data
-    results = restApi.fetchTableRecordsRetryableMode(tableName, pluginConf.getValueType(), pluginConf.getStartDate(),
-                                                     pluginConf.getEndDate(), split.getOffset(),
+    results = restApi.fetchTableRecordsRetryableMode(tableName, pluginConf.getValueType(), split.getFilterQuery(),
+            split.getOffset(),
                                                      pluginConf.getPageSize());
     LOG.debug("Results size={}", results.size());
 

--- a/src/main/java/io/cdap/plugin/servicenow/source/ServiceNowSource.java
+++ b/src/main/java/io/cdap/plugin/servicenow/source/ServiceNowSource.java
@@ -84,7 +84,9 @@ public class ServiceNowSource extends BatchSource<NullWritable, StructuredRecord
                                                                                  conf.getTableName(),
                                                                                  conf.getApplicationName(),
                                                                                  conf.getValueType(),
-                                                                                 conf.getUseConnection());
+                                                                                 conf.getUseConnection(),
+                                                                                 conf.getStartDate(),
+                                                                                 conf.getEndDate());
       stageConfigurer.setOutputSchema(tableInfo.stream().findFirst().get().getSchema());
     } else if (conf.getQueryMode() == SourceQueryMode.REPORTING) {
       stageConfigurer.setOutputSchema(null);

--- a/src/main/java/io/cdap/plugin/servicenow/util/Util.java
+++ b/src/main/java/io/cdap/plugin/servicenow/util/Util.java
@@ -17,6 +17,8 @@
 package io.cdap.plugin.servicenow.util;
 
 import com.google.common.base.Strings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -26,6 +28,12 @@ import java.util.Date;
  * Utility class.
  */
 public class Util {
+  private static final Logger LOG = LoggerFactory.getLogger(Util.class);
+  private static final String DATE_RANGE_TEMPLATE = "%sBETWEENjavascript:gs.dateGenerate('%s','start')" +
+          "@javascript:gs.dateGenerate('%s','end')";
+  private static final String FIELD_CREATED_ON = "sys_created_on";
+  private static final String FIELD_UPDATED_ON = "sys_updated_on";
+
   /**
    * Utility function to check if incoming string is empty or not.
    *
@@ -55,5 +63,29 @@ public class Util {
       return false;
     }
     return true;
+  }
+
+  /**
+   * Generates a date range query for ServiceNow.
+   *
+   * @param startDate The start date
+   * @param endDate The end date
+   * @return The date range query
+   */
+  public static String generateDateRangeQuery(String startDate, String endDate) {
+    if (Util.isNullOrEmpty(startDate) || Util.isNullOrEmpty(endDate)) {
+      return "";
+    }
+
+    String dateRange = "";
+    try {
+      String createdOnDateRange = String.format(DATE_RANGE_TEMPLATE, FIELD_CREATED_ON, startDate, endDate);
+      String updatedOnDateRange = String.format(DATE_RANGE_TEMPLATE, FIELD_UPDATED_ON, startDate, endDate);
+      dateRange = String.format("%s^OR%s", createdOnDateRange, updatedOnDateRange);
+      LOG.debug("Generated query: {}", dateRange);
+    } catch (Exception e) {
+      LOG.error("Error in generateDateRangeQuery, hence ignoring the date range", e);
+    }
+    return dateRange;
   }
 }

--- a/src/test/java/io/cdap/plugin/servicenow/apiclient/ServiceNowTableAPIClientImplTest.java
+++ b/src/test/java/io/cdap/plugin/servicenow/apiclient/ServiceNowTableAPIClientImplTest.java
@@ -42,16 +42,14 @@ public class ServiceNowTableAPIClientImplTest {
             Mockito.anyString(),
             Mockito.any(),
             Mockito.anyString(),
-            Mockito.anyString(),
             Mockito.anyInt(),
             Mockito.anyInt());
     List<Map<String, String>> receivedResults =
         implSpy.fetchTableRecordsRetryableMode(
-            "test", SourceValueType.SHOW_DISPLAY_VALUE, "", "", 0, 0);
+            "test", SourceValueType.SHOW_DISPLAY_VALUE, "", 0, 0);
     Mockito.verify(implSpy, Mockito.times(2)).fetchTableRecords(
         Mockito.anyString(),
         Mockito.any(),
-        Mockito.anyString(),
         Mockito.anyString(),
         Mockito.anyInt(),
         Mockito.anyInt());
@@ -74,13 +72,12 @@ public class ServiceNowTableAPIClientImplTest {
             Mockito.anyString(),
             Mockito.any(),
             Mockito.anyString(),
-            Mockito.anyString(),
             Mockito.anyInt(),
             Mockito.anyInt());
     exceptionRule.expect(ServiceNowAPIException.class);
     exceptionRule.expectMessage("Data Recovery failed for batch 0 to 0.");
     implSpy.fetchTableRecordsRetryableMode(
-        "test", SourceValueType.SHOW_DISPLAY_VALUE, "", "", 0, 0);
+        "test", SourceValueType.SHOW_DISPLAY_VALUE, "", 0, 0);
   }
 
   @Test

--- a/src/test/java/io/cdap/plugin/servicenow/connector/ServiceNowConnectorTest.java
+++ b/src/test/java/io/cdap/plugin/servicenow/connector/ServiceNowConnectorTest.java
@@ -160,7 +160,7 @@ public class ServiceNowConnectorTest {
     SourceValueType valueType = SourceValueType.SHOW_DISPLAY_VALUE;
     Mockito.when(ServiceNowInputFormat.fetchTableInfo(mode, serviceNowSourceConfig.getConnection(),
                                                       serviceNowSourceConfig.getTableName(),
-                                                      null, valueType, true)).thenReturn(list);
+                                                      null, valueType, true, null, null)).thenReturn(list);
 
     ConnectorSpec connectorSpec = serviceNowConnector.generateSpec(new MockConnectorContext
                                                                      (new MockConnectorConfigurer()),

--- a/src/test/java/io/cdap/plugin/servicenow/source/ServiceNowInputFormatTest.java
+++ b/src/test/java/io/cdap/plugin/servicenow/source/ServiceNowInputFormatTest.java
@@ -167,7 +167,7 @@ public class ServiceNowInputFormatTest {
     SourceApplication application = SourceApplication.PROCUREMENT;
     SourceValueType valueType = SourceValueType.SHOW_ACTUAL_VALUE;
     Assert.assertEquals(1, ServiceNowInputFormat.fetchTableInfo(mode, connectorConfig, "table",
-                                                                application, valueType, true).size());
+                                                                application, valueType, true, null, null).size());
   }
 
   @Test
@@ -275,7 +275,7 @@ public class ServiceNowInputFormatTest {
     SourceApplication application = SourceApplication.PROCUREMENT;
     SourceValueType valueType = SourceValueType.SHOW_ACTUAL_VALUE;
     Assert.assertEquals(3, ServiceNowInputFormat.fetchTableInfo(mode, connectorConfig, "table",
-                                                                application, valueType, true).size());
+                                                                application, valueType, true, null, null).size());
   }
 
   @Test
@@ -316,6 +316,6 @@ public class ServiceNowInputFormatTest {
     SourceApplication application = SourceApplication.PROCUREMENT;
     SourceValueType valueType = SourceValueType.SHOW_ACTUAL_VALUE;
     Assert.assertTrue(ServiceNowInputFormat.fetchTableInfo(mode, connectorConfig, "table",
-                                                           application, valueType, true).isEmpty());
+                                                           application, valueType, true, null, null).isEmpty());
   }
 }

--- a/src/test/java/io/cdap/plugin/servicenow/source/ServiceNowInputSplitTest.java
+++ b/src/test/java/io/cdap/plugin/servicenow/source/ServiceNowInputSplitTest.java
@@ -27,7 +27,7 @@ public class ServiceNowInputSplitTest {
 
   @Test
   public void testInputSplitWithNonEmptyTableName() throws IOException, InterruptedException {
-    ServiceNowInputSplit actualServiceNowInputSplit = new ServiceNowInputSplit("Table Name", 2);
+    ServiceNowInputSplit actualServiceNowInputSplit = new ServiceNowInputSplit("Table Name", 2, null);
     Assert.assertEquals(0L, actualServiceNowInputSplit.getLength());
     Assert.assertEquals(2, actualServiceNowInputSplit.getOffset());
     Assert.assertEquals("Table Name", actualServiceNowInputSplit.getTableName());
@@ -43,22 +43,23 @@ public class ServiceNowInputSplitTest {
 
   @Test
   public void testReadFields() throws IOException {
-    ServiceNowInputSplit serviceNowInputSplit = new ServiceNowInputSplit("Table Name", 2);
+    ServiceNowInputSplit serviceNowInputSplit = new ServiceNowInputSplit("Table Name", 2, null);
     ObjectInputStream objectInputStream = Mockito.mock(ObjectInputStream.class);
     Mockito.when(objectInputStream.readInt()).thenReturn(1);
     Mockito.when(objectInputStream.readUTF()).thenReturn("Utf");
     serviceNowInputSplit.readFields(objectInputStream);
     Mockito.verify(objectInputStream).readInt();
-    Mockito.verify(objectInputStream).readUTF();
+    Mockito.verify(objectInputStream, Mockito.times(2)).readUTF();
     Assert.assertEquals("Utf", serviceNowInputSplit.getTableName());
     Assert.assertEquals(1, serviceNowInputSplit.getOffset());
+    Assert.assertEquals("Utf", serviceNowInputSplit.getFilterQuery());
   }
 
   @Test
   public void testGetLocations() throws IOException, InterruptedException {
-    Assert.assertEquals(String[].class, new ServiceNowInputSplit("Table Name", 2).getLocations().
+    Assert.assertEquals(String[].class, new ServiceNowInputSplit("Table Name", 2, null).getLocations().
       getClass());
-    Assert.assertEquals(0, (new ServiceNowInputSplit("Table Name", 2)).getLocations().length);
+    Assert.assertEquals(0, (new ServiceNowInputSplit("Table Name", 2, null)).getLocations().length);
   }
   
   @Test
@@ -67,7 +68,7 @@ public class ServiceNowInputSplitTest {
     String tableName = "Table";
     int offset = 0;
 
-    ServiceNowInputSplit servicenowinputsplit = new ServiceNowInputSplit(tableName, offset);
+    ServiceNowInputSplit servicenowinputsplit = new ServiceNowInputSplit(tableName, offset, null);
     String actualValue = servicenowinputsplit.getTableName();
     Assert.assertEquals(expectedValue, actualValue);
   }
@@ -77,7 +78,7 @@ public class ServiceNowInputSplitTest {
     int expectedValue = 0;
     String tableName = "Table";
     int offset = 0;
-    ServiceNowInputSplit servicenowinputsplit = new ServiceNowInputSplit(tableName, offset);
+    ServiceNowInputSplit servicenowinputsplit = new ServiceNowInputSplit(tableName, offset, null);
     int actualValue = servicenowinputsplit.getOffset();
     Assert.assertEquals(expectedValue, actualValue);
   }
@@ -88,7 +89,7 @@ public class ServiceNowInputSplitTest {
       String tableName = "";
       int offset = 0;
 
-      ServiceNowInputSplit serviceNowInputSplit = new ServiceNowInputSplit(tableName, offset);
+      ServiceNowInputSplit serviceNowInputSplit = new ServiceNowInputSplit(tableName, offset, null);
       serviceNowInputSplit.write(dataOutput);
   }
 
@@ -98,7 +99,7 @@ public class ServiceNowInputSplitTest {
       String tableName = "";
       int offset = 0;
 
-      ServiceNowInputSplit servicenowinputsplit = new ServiceNowInputSplit(tableName, offset);
+      ServiceNowInputSplit servicenowinputsplit = new ServiceNowInputSplit(tableName, offset, null);
       servicenowinputsplit.readFields(dataInput);
   }
 }

--- a/src/test/java/io/cdap/plugin/servicenow/source/ServiceNowMultiInputFormatTest.java
+++ b/src/test/java/io/cdap/plugin/servicenow/source/ServiceNowMultiInputFormatTest.java
@@ -70,16 +70,16 @@ public class ServiceNowMultiInputFormatTest {
     serviceNowTableInfos.add(serviceNowTableInfo);
     PowerMockito.mockStatic(ServiceNowMultiInputFormat.class);
     SourceValueType valueType = SourceValueType.SHOW_DISPLAY_VALUE;
-    PowerMockito.when(ServiceNowMultiInputFormat.fetchTablesInfo(connectorConfig, "table", true)).
+    PowerMockito.when(ServiceNowMultiInputFormat.fetchTablesInfo(connectorConfig, "table", true, null, null)).
       thenReturn(serviceNowTableInfos);
     Assert.assertEquals(1, ServiceNowMultiInputFormat
-      .fetchTablesInfo(connectorConfig, "table", true)
+      .fetchTablesInfo(connectorConfig, "table", true, null, null)
       .size());
   }
 
   @Test
   public void testFetchTablesInfoWithEmptyTableNames() {
     SourceValueType valueType = SourceValueType.SHOW_DISPLAY_VALUE;
-    Assert.assertTrue(ServiceNowMultiInputFormat.fetchTablesInfo(connectorConfig, "", true).isEmpty());
+    Assert.assertTrue(ServiceNowMultiInputFormat.fetchTablesInfo(connectorConfig, "", true, null, null).isEmpty());
   }
 }

--- a/src/test/java/io/cdap/plugin/servicenow/source/ServiceNowMultiRecordReaderTest.java
+++ b/src/test/java/io/cdap/plugin/servicenow/source/ServiceNowMultiRecordReaderTest.java
@@ -122,7 +122,7 @@ public class ServiceNowMultiRecordReaderTest {
   @Test
   public void testFetchData() throws ServiceNowAPIException, IOException {
     String tableName = serviceNowMultiSourceConfig.getTableNames();
-    ServiceNowInputSplit split = new ServiceNowInputSplit(tableName, 1);
+    ServiceNowInputSplit split = new ServiceNowInputSplit(tableName, 1, null);
 
     List<Map<String, String>> results = new ArrayList<>();
     Map<String, String> map = new HashMap<>();
@@ -176,7 +176,7 @@ public class ServiceNowMultiRecordReaderTest {
 
     String tableName = serviceNowMultiSourceConfig.getTableNames();
     ServiceNowTableAPIClientImpl restApi = Mockito.mock(ServiceNowTableAPIClientImpl.class);
-    ServiceNowInputSplit split = new ServiceNowInputSplit(tableName, 1);
+    ServiceNowInputSplit split = new ServiceNowInputSplit(tableName, 1, null);
     List<Map<String, String>> results = new ArrayList<>();
     Map<String, String> map = new HashMap<>();
     map.put("calendar_integration", "1");
@@ -189,7 +189,7 @@ public class ServiceNowMultiRecordReaderTest {
     map.put("sys_created_on", "2019-04-05 21:09:12");
     results.add(map);
     restApi.fetchTableRecords(tableName, serviceNowMultiSourceConfig.getValueType(),
-                              serviceNowMultiSourceConfig.getStartDate(), serviceNowMultiSourceConfig.getEndDate(),
+                              split.getFilterQuery(),
                               split.getOffset(),
                               serviceNowMultiSourceConfig.getPageSize());
 

--- a/src/test/java/io/cdap/plugin/servicenow/source/ServiceNowRecordReaderTest.java
+++ b/src/test/java/io/cdap/plugin/servicenow/source/ServiceNowRecordReaderTest.java
@@ -287,7 +287,7 @@ public class ServiceNowRecordReaderTest {
     String tableName = serviceNowSourceConfig.getTableName();
     SourceValueType valueType = serviceNowSourceConfig.getValueType();
     ServiceNowTableAPIClientImpl restApi = Mockito.mock(ServiceNowTableAPIClientImpl.class);
-    ServiceNowInputSplit split = new ServiceNowInputSplit(tableName, 1);
+    ServiceNowInputSplit split = new ServiceNowInputSplit(tableName, 1, null);
     ServiceNowRecordReader serviceNowRecordReader = new ServiceNowRecordReader(serviceNowSourceConfig);
     List<Map<String, String>> results = new ArrayList<>();
     Map<String, String> map = new HashMap<>();
@@ -311,8 +311,7 @@ public class ServiceNowRecordReaderTest {
     response.setTotalRecordCount(1);
     PowerMockito.whenNew(ServiceNowTableAPIClientImpl.class).withAnyArguments().thenReturn(restApi);
     Mockito.when(restApi.fetchTableRecordsRetryableMode(tableName, serviceNowSourceConfig.getValueType(),
-                                                        serviceNowSourceConfig.getStartDate(), serviceNowSourceConfig.
-                                                          getEndDate(), split.getOffset(),
+            split.getFilterQuery(), split.getOffset(),
                                                         serviceNowSourceConfig.getPageSize())).thenReturn(results);
     Mockito.when(restApi.fetchTableSchema(tableName, valueType))
       .thenReturn(Schema.recordOf(Schema.Field.of("calendar_integration", Schema.of(Schema.Type.STRING))));
@@ -340,7 +339,7 @@ public class ServiceNowRecordReaderTest {
     serviceNowRecordReader = new ServiceNowRecordReader(serviceNowSourceConfig);
     String tableName = serviceNowSourceConfig.getTableName();
     ServiceNowTableAPIClientImpl restApi = Mockito.mock(ServiceNowTableAPIClientImpl.class);
-    ServiceNowInputSplit split = new ServiceNowInputSplit(tableName, 1);
+    ServiceNowInputSplit split = new ServiceNowInputSplit(tableName, 1, null);
     ServiceNowRecordReader serviceNowRecordReader = new ServiceNowRecordReader(serviceNowSourceConfig);
     List<Map<String, String>> results = new ArrayList<>();
     Map<String, String> map = new HashMap<>();
@@ -364,8 +363,7 @@ public class ServiceNowRecordReaderTest {
     response.setTotalRecordCount(1);
     PowerMockito.whenNew(ServiceNowTableAPIClientImpl.class).withAnyArguments().thenReturn(restApi);
     Mockito.when(restApi.fetchTableRecordsRetryableMode(tableName, serviceNowSourceConfig.getValueType(),
-                                                        serviceNowSourceConfig.getStartDate(),
-                                                        serviceNowSourceConfig.getEndDate(), split.getOffset(),
+                                                        split.getFilterQuery(), split.getOffset(),
                                                         serviceNowSourceConfig.getPageSize())).thenReturn(results);
     Mockito.when(restApi.fetchTableSchema(tableName, serviceNowSourceConfig.getValueType()))
       .thenReturn(Schema.recordOf(Schema.Field.of("calendar_integration", Schema.of(Schema.Type.STRING))));
@@ -391,12 +389,12 @@ public class ServiceNowRecordReaderTest {
 
     String tableName = serviceNowSourceConfig.getTableName();
     ServiceNowTableAPIClientImpl restApi = Mockito.mock(ServiceNowTableAPIClientImpl.class);
-    ServiceNowInputSplit split = new ServiceNowInputSplit(tableName, 1);
+    ServiceNowInputSplit split = new ServiceNowInputSplit(tableName, 1, null);
     ServiceNowRecordReader serviceNowRecordReader = new ServiceNowRecordReader(serviceNowSourceConfig);
     List<Map<String, String>> results = new ArrayList<>();
     PowerMockito.whenNew(ServiceNowTableAPIClientImpl.class).withAnyArguments().thenReturn(restApi);
     Mockito.when(restApi.fetchTableRecords(tableName, serviceNowSourceConfig.getValueType(),
-                                           serviceNowSourceConfig.getStartDate(), serviceNowSourceConfig.getEndDate(),
+                                           split.getFilterQuery(),
                                            split.getOffset(),
                                            serviceNowSourceConfig.getPageSize())).thenReturn(results);
     ServiceNowTableDataResponse response = new ServiceNowTableDataResponse();

--- a/src/test/java/io/cdap/plugin/servicenow/source/ServiceNowSourceTest.java
+++ b/src/test/java/io/cdap/plugin/servicenow/source/ServiceNowSourceTest.java
@@ -170,7 +170,7 @@ public class ServiceNowSourceTest {
       "}";
     PowerMockito.mockStatic(ServiceNowInputFormat.class);
     Mockito.when(ServiceNowInputFormat.fetchTableInfo(Mockito.any(), Mockito.any(), Mockito.anyString(),
-      Mockito.any(), Mockito.any(), Mockito.any())).thenReturn(tableInfo);
+      Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any())).thenReturn(tableInfo);
     RestAPIResponse restAPIResponse = new RestAPIResponse(headers, responseBody, null);
     Mockito.when(restApi.executeGetWithRetries(Mockito.any())).thenReturn(restAPIResponse);
     Mockito.when(restApi.parseResponseToResultListOfMap(restAPIResponse.getResponseBody())).thenReturn(result);


### PR DESCRIPTION
Support DTS Filter Queries in Split class.

Overview: To ensure consistency between CDF and DTS, this change updates the Split class to handle filter queries directly. While CDF currently supports filtering via start/end dates, this PR streamlines that process into a more flexible filterQuery format.

Added filterQuery as a new parameter in the Split class.

