### PR TITLE
[🍒][PLUGIN-1943] Fix for array support when fetching display values

### DIFF
--- a/src/main/java/io/cdap/plugin/servicenow/util/SchemaBuilder.java
+++ b/src/main/java/io/cdap/plugin/servicenow/util/SchemaBuilder.java
@@ -79,6 +79,7 @@ public class SchemaBuilder {
       case "glide_time":
         return Schema.of(Schema.LogicalType.TIME_MICROS);
       case "glide_list":
+      case "glide_static_list":
         return legacyMapping.equals(Boolean.FALSE) ? Schema.arrayOf(Schema.of(Schema.Type.STRING)) :
           Schema.of(Schema.Type.STRING);
       case "reference":

--- a/src/test/java/io/cdap/plugin/servicenow/apiclient/ServiceNowTableAPIClientImplTest.java
+++ b/src/test/java/io/cdap/plugin/servicenow/apiclient/ServiceNowTableAPIClientImplTest.java
@@ -300,4 +300,80 @@ public class ServiceNowTableAPIClientImplTest {
     Assert.assertEquals(Schema.Type.STRING,
                         schema.getField("u_glide_array3").getSchema().getUnionSchemas().get(0).getType());
   }
+
+  @Test
+  public void testFetchTableSchema_WithGlide_Static_ListType_ParseAsArray() throws Exception {
+    ServiceNowConnectorConfig mockConfig = Mockito.mock(ServiceNowConnectorConfig.class);
+    ServiceNowTableAPIClientImpl impl = new ServiceNowTableAPIClientImpl(mockConfig, true);
+    ServiceNowTableAPIClientImpl implSpy = Mockito.spy(impl);
+    String jsonResponse = "{\n" +
+      "  \"result\": {\n" +
+      "    \"columns\": {\n" +
+      "      \"u_glide_array2\": {\n" +
+      "         \"label\": \"glide_array2\",\n" +
+      "         \"type\": \"glide_static_list\",\n" +
+      "         \"base_type\": \"string\",\n" +
+      "         \"name\": \"u_glide_array2\",\n" +
+      "         \"internal_type\": \"glide_list\"\n" +
+      "       },\n" +
+      "         \"u_glide_array3\": {\n" +
+      "         \"label\": \"glide_array3\",\n" +
+      "         \"type\": \"glide_static_list\",\n" +
+      "         \"base_type\": \"string\",\n" +
+      "         \"name\": \"u_glide_array3\",\n" +
+      "         \"internal_type\": \"glide_list\"\n" +
+      "       }\n" +
+      "    }\n" +
+      "  }\n" +
+      "}";
+    RestAPIResponse mockResponse = new RestAPIResponse(Collections.emptyMap(), jsonResponse, null);
+    Mockito.doReturn(mockResponse).when(implSpy).executeGetWithRetries(Mockito.any());
+    Schema schema = implSpy.fetchTableSchema("u_custom_13", "dummy-access-token",
+      SourceValueType.SHOW_DISPLAY_VALUE, SchemaType.METADATA_API_BASED, false);
+    Assert.assertNotNull(schema);
+    Assert.assertEquals("record", schema.getDisplayName());
+    Assert.assertEquals(2, schema.getFields().size());
+    Assert.assertEquals(Schema.Type.ARRAY,
+                        schema.getField("u_glide_array2").getSchema().getUnionSchemas().get(0).getType());
+    Assert.assertEquals(Schema.Type.ARRAY,
+                        schema.getField("u_glide_array3").getSchema().getUnionSchemas().get(0).getType());
+  }
+
+  @Test
+  public void testFetchTableSchema_WithGlide_Static_ListType_ParseAsString() throws Exception {
+    ServiceNowConnectorConfig mockConfig = Mockito.mock(ServiceNowConnectorConfig.class);
+    ServiceNowTableAPIClientImpl impl = new ServiceNowTableAPIClientImpl(mockConfig, true);
+    ServiceNowTableAPIClientImpl implSpy = Mockito.spy(impl);
+    String jsonResponse = "{\n" +
+      "  \"result\": {\n" +
+      "    \"columns\": {\n" +
+      "      \"u_glide_array2\": {\n" +
+      "         \"label\": \"glide_array2\",\n" +
+      "         \"type\": \"glide_static_list\",\n" +
+      "         \"base_type\": \"string\",\n" +
+      "         \"name\": \"u_glide_array2\",\n" +
+      "         \"internal_type\": \"glide_list\"\n" +
+      "       },\n" +
+      "         \"u_glide_array3\": {\n" +
+      "         \"label\": \"glide_array3\",\n" +
+      "         \"type\": \"glide_static_list\",\n" +
+      "         \"base_type\": \"string\",\n" +
+      "         \"name\": \"u_glide_array3\",\n" +
+      "         \"internal_type\": \"glide_list\"\n" +
+      "       }\n" +
+      "    }\n" +
+      "  }\n" +
+      "}";
+    RestAPIResponse mockResponse = new RestAPIResponse(Collections.emptyMap(), jsonResponse, null);
+    Mockito.doReturn(mockResponse).when(implSpy).executeGetWithRetries(Mockito.any());
+    Schema schema = implSpy.fetchTableSchema("u_custom_13", "dummy-access-token",
+      SourceValueType.SHOW_DISPLAY_VALUE, SchemaType.METADATA_API_BASED, true);
+    Assert.assertNotNull(schema);
+    Assert.assertEquals("record", schema.getDisplayName());
+    Assert.assertEquals(2, schema.getFields().size());
+    Assert.assertEquals(Schema.Type.STRING,
+                        schema.getField("u_glide_array2").getSchema().getUnionSchemas().get(0).getType());
+    Assert.assertEquals(Schema.Type.STRING,
+                        schema.getField("u_glide_array3").getSchema().getUnionSchemas().get(0).getType());
+  }
 }


### PR DESCRIPTION
[🍒]

🍒 [cherrypick]

**Commits:**
- https://github.com/data-integrations/servicenow-plugins/pull/139/changes/dd1ffd2ecf96e145ba67385850848d5cb470eff2

**PR:**
- https://github.com/data-integrations/servicenow-plugins/pull/139 [Reviewer: @itsankit-google]

**JIRA:**
 - [PLUGIN-1943](https://cdap.atlassian.net/browse/PLUGIN-1943) 

**Description:**
This change enhances the schema construction logic to treat both `glide_list` (when actual values are requested) and `glide_static_list` (when display values are requested) as eligible for `ARRAY<STRING>` mapping when the flag `legacyMapping` flag is set to `false`.


[PLUGIN-1943]: https://cdap.atlassian.net/browse/PLUGIN-1943?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ