### PR TITLE
[Cherrypick][PLUGIN-1952] and version update for unsupported field name message

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
   <groupId>io.cdap.plugin</groupId>
   <artifactId>servicenow-plugins</artifactId>
-  <version>1.2.10</version>
+  <version>1.2.11-SNAPSHOT</version>
   <name>ServiceNow Plugins</name>
   <packaging>jar</packaging>
   <description>Plugins for ServiceNow</description>

--- a/src/main/java/io/cdap/plugin/servicenow/connector/ServiceNowRecordConverter.java
+++ b/src/main/java/io/cdap/plugin/servicenow/connector/ServiceNowRecordConverter.java
@@ -121,13 +121,13 @@ public class ServiceNowRecordConverter {
         recordBuilder.set(fieldName, fieldValue);
         return;
       case DOUBLE:
-        recordBuilder.set(fieldName, convertToDoubleValue(fieldValue));
+        recordBuilder.set(fieldName, convertToDoubleValue(fieldValue, fieldName));
         return;
       case INT:
-        recordBuilder.set(fieldName, convertToIntegerValue(fieldValue));
+        recordBuilder.set(fieldName, convertToIntegerValue(fieldValue, fieldName));
         return;
       case BOOLEAN:
-        recordBuilder.set(fieldName, convertToBooleanValue(fieldValue));
+        recordBuilder.set(fieldName, convertToBooleanValue(fieldValue, fieldName));
         return;
       case ARRAY:
         recordBuilder.set(fieldName, legacyMapping.equals(Boolean.FALSE) ? convertToList(fieldValue) : fieldValue);
@@ -150,33 +150,33 @@ public class ServiceNowRecordConverter {
   }
 
   @VisibleForTesting
-  public static Double convertToDoubleValue(String fieldValue) {
+  public static Double convertToDoubleValue(String fieldValue, String fieldName) {
     try {
       return NumberFormat.getNumberInstance(Locale.US).parse(fieldValue).doubleValue();
     } catch (ParseException exception) {
       throw new UnexpectedFormatException(
-        String.format("Field with value '%s' is not in valid format.", fieldValue), exception);
+        String.format("Field '%s' with value '%s' is not in valid format.", fieldName, fieldValue), exception);
     }
   }
 
   @VisibleForTesting
-  public static Integer convertToIntegerValue(String fieldValue) {
+  public static Integer convertToIntegerValue(String fieldValue, String fieldName) {
     try {
       return NumberFormat.getNumberInstance(java.util.Locale.US).parse(fieldValue).intValue();
     } catch (ParseException exception) {
       throw new UnexpectedFormatException(
-        String.format("Field with value '%s' is not in valid format.", fieldValue), exception);
+        String.format("Field '%s' with value '%s' is not in valid format.", fieldName, fieldValue), exception);
     }
   }
 
   @VisibleForTesting
-  public static Boolean convertToBooleanValue(String fieldValue) {
+  public static Boolean convertToBooleanValue(String fieldValue, String fieldName) {
     if (fieldValue.equalsIgnoreCase(Boolean.TRUE.toString()) ||
                                       fieldValue.equalsIgnoreCase(Boolean.FALSE.toString())) {
       return Boolean.parseBoolean(fieldValue);
     }
     throw new UnexpectedFormatException(
-      String.format("Field with value '%s' is not in valid format.", fieldValue));
+      String.format("Field '%s' with value '%s' is not in valid format.", fieldName, fieldValue));
     
   }
 

--- a/src/test/java/io/cdap/plugin/servicenow/source/ServiceNowMultiRecordReaderTest.java
+++ b/src/test/java/io/cdap/plugin/servicenow/source/ServiceNowMultiRecordReaderTest.java
@@ -101,22 +101,79 @@ public class ServiceNowMultiRecordReaderTest {
 
   @Test
   public void testConvertToDoubleValue() throws ParseException {
-    Assert.assertEquals(42.0, ServiceNowRecordConverter.convertToDoubleValue("42"), 0.0);
+    Assert.assertEquals(42.0, ServiceNowRecordConverter.convertToDoubleValue("42", "code"), 0.0);
+  }
+
+  @Test
+  public void testConvertToDoubleValue_ThrowsExceptionForBadData() {
+    String badValue = "not_a_number";
+    String testFieldName = "code";
+
+    try {
+      // 1. Attempt the conversion with bad data
+      ServiceNowRecordConverter.convertToDoubleValue(badValue, testFieldName);
+
+      // 2. If the line above DOES NOT throw an error, fail the test immediately
+      Assert.fail("Expected an UnexpectedFormatException to be thrown, but it was not.");
+
+    } catch (UnexpectedFormatException exception) {
+      // 3. Catch the exception and assert the message matches perfectly
+      String expectedMessage = "Field 'code' with value 'not_a_number' is not in valid format.";
+      Assert.assertEquals(expectedMessage, exception.getMessage());
+    }
   }
 
   @Test
   public void testConvertToIntegerValue() throws ParseException {
-    Assert.assertEquals(42, ServiceNowRecordConverter.convertToIntegerValue("42").intValue());
+    Assert.assertEquals(42, ServiceNowRecordConverter.convertToIntegerValue("42", "code").intValue());
+  }
+
+  @Test
+  public void testConvertToIntegerValue_ThrowsExceptionForBadData() {
+    String badValue = "not_an_integer";
+    String testFieldName = "code";
+
+    try {
+      // Attempt the conversion with bad data
+      ServiceNowRecordConverter.convertToDoubleValue(badValue, testFieldName);
+
+      // If the line above DOES NOT throw an error, fail the test immediately
+      Assert.fail("Expected an UnexpectedFormatException to be thrown, but it was not.");
+
+    } catch (UnexpectedFormatException exception) {
+      // Catch the exception and assert the message matches perfectly
+      String expectedMessage = "Field 'code' with value 'not_an_integer' is not in valid format.";
+      Assert.assertEquals(expectedMessage, exception.getMessage());
+    }
   }
 
   @Test
   public void testConvertToBooleanValue() {
-    Assert.assertTrue(ServiceNowRecordConverter.convertToBooleanValue("true"));
+    Assert.assertTrue(ServiceNowRecordConverter.convertToBooleanValue("true", "accept"));
   }
 
   @Test(expected = UnexpectedFormatException.class)
   public void testConvertToBooleanValueForInvalidFieldValue() {
-    Assert.assertTrue(ServiceNowRecordConverter.convertToBooleanValue("1"));
+    Assert.assertTrue(ServiceNowRecordConverter.convertToBooleanValue("1", "accept"));
+  }
+
+  @Test
+  public void testConvertToBooleanValue_ThrowsExceptionForBadData() {
+    String badValue = "not_a_boolean";
+    String testFieldName = "accept";
+
+    try {
+      // Attempt the conversion with bad data
+      ServiceNowRecordConverter.convertToDoubleValue(badValue, testFieldName);
+
+      // If the line above DOES NOT throw an error, fail the test immediately
+      Assert.fail("Expected an UnexpectedFormatException to be thrown, but it was not.");
+
+    } catch (UnexpectedFormatException exception) {
+      // Catch the exception and assert the message matches perfectly
+      String expectedMessage = "Field 'accept' with value 'not_a_boolean' is not in valid format.";
+      Assert.assertEquals(expectedMessage, exception.getMessage());
+    }
   }
 
   @Test

--- a/src/test/java/io/cdap/plugin/servicenow/source/ServiceNowRecordReaderTest.java
+++ b/src/test/java/io/cdap/plugin/servicenow/source/ServiceNowRecordReaderTest.java
@@ -263,23 +263,80 @@ public class ServiceNowRecordReaderTest {
 
   @Test
   public void testConvertToDoubleValue() throws ParseException {
-    Assert.assertEquals(42.0, ServiceNowRecordConverter.convertToDoubleValue("42"),
+    Assert.assertEquals(42.0, ServiceNowRecordConverter.convertToDoubleValue("42", "code"),
                         0.0);
   }
 
   @Test
+  public void testConvertToDoubleValue_ThrowsExceptionForBadData() {
+    String badValue = "not_a_number";
+    String testFieldName = "code";
+
+    try {
+      // 1. Attempt the conversion with bad data
+      ServiceNowRecordConverter.convertToDoubleValue(badValue, testFieldName);
+
+      // 2. If the line above DOES NOT throw an error, fail the test immediately
+      Assert.fail("Expected an UnexpectedFormatException to be thrown, but it was not.");
+
+    } catch (UnexpectedFormatException exception) {
+      // 3. Catch the exception and assert the message matches perfectly
+      String expectedMessage = "Field 'code' with value 'not_a_number' is not in valid format.";
+      Assert.assertEquals(expectedMessage, exception.getMessage());
+    }
+  }
+
+  @Test
   public void testConvertToIntegerValue() throws ParseException {
-    Assert.assertEquals(42, ServiceNowRecordConverter.convertToIntegerValue("42").intValue());
+    Assert.assertEquals(42, ServiceNowRecordConverter.convertToIntegerValue("42", "code").intValue());
+  }
+
+  @Test
+  public void testConvertToIntegerValue_ThrowsExceptionForBadData() {
+    String badValue = "not_an_integer";
+    String testFieldName = "code";
+
+    try {
+      // Attempt the conversion with bad data
+      ServiceNowRecordConverter.convertToDoubleValue(badValue, testFieldName);
+
+      // If the line above DOES NOT throw an error, fail the test immediately
+      Assert.fail("Expected an UnexpectedFormatException to be thrown, but it was not.");
+
+    } catch (UnexpectedFormatException exception) {
+      // Catch the exception and assert the message matches perfectly
+      String expectedMessage = "Field 'code' with value 'not_an_integer' is not in valid format.";
+      Assert.assertEquals(expectedMessage, exception.getMessage());
+    }
   }
 
   @Test
   public void testConvertToBooleanValue() {
-    Assert.assertTrue(ServiceNowRecordConverter.convertToBooleanValue("true"));
+    Assert.assertTrue(ServiceNowRecordConverter.convertToBooleanValue("true", "accept"));
   }
 
   @Test(expected = UnexpectedFormatException.class)
   public void testConvertToBooleanValueForInvalidFieldValue() {
-    Assert.assertTrue(ServiceNowRecordConverter.convertToBooleanValue("1"));
+    Assert.assertTrue(ServiceNowRecordConverter.convertToBooleanValue("1", "accept"));
+  }
+
+  @Test
+  public void testConvertToBooleanValue_ThrowsExceptionForBadData() {
+    String badValue = "not_a_boolean";
+    String testFieldName = "accept";
+
+    try {
+      // Attempt the conversion with bad data
+      ServiceNowRecordConverter.convertToDoubleValue(badValue, testFieldName);
+
+      // If the line above DOES NOT throw an error, fail the test immediately
+      Assert.fail("Expected an UnexpectedFormatException to be thrown, but it was not.");
+
+    } catch (UnexpectedFormatException exception) {
+      // Catch the exception and assert the message matches perfectly
+      String expectedMessage = "Field 'accept' with value 'not_a_boolean' is not in valid format.";
+      Assert.assertEquals(expectedMessage, exception.getMessage());
+    }
   }
 
   @Test


### PR DESCRIPTION
cherry picked: d0ae86f15af08fc26ba234c670e950958ee0454a
PR Link: https://github.com/data-integrations/servicenow-plugins/pull/147

fix: include specific field name in error message

What:
Updated the validation logic / error handler to append the exact field name to the resulting output message.

Why:
Previously, the message was too generic, making it difficult to identify exactly which data column triggered the issue. Including the specific field name provides immediate context.

Testing:
Tested by creating the jar of this plugin in local and embedding it with Servicenow connector.

updated version from 1.2.10 to 1.2.11-SNAPSHOT
