### PR TITLE
[PLUGIN-1959] Add proxy support for ServiceNow plugins

### DIFF
--- a/docs/ServiceNow-batchsink.md
+++ b/docs/ServiceNow-batchsink.md
@@ -24,6 +24,15 @@ You also can use the macro function ${conn(connection-name)}.
 
 **Password**: The password for ServiceNow Instance.
 
+**Proxy URL**: Proxy URL through which all the ServiceNow API calls are routed. For example,
+`http://proxy.example.com:8080`. If no scheme is specified (for example, `proxy.example.com:8080`),
+it defaults to `http`. Specify `https://` explicitly
+when using an HTTPS proxy. Leave it empty to connect to ServiceNow directly.
+
+**Proxy Username**: The username to authenticate with the proxy server, if the proxy requires authentication.
+
+**Proxy Password**: The password to authenticate with the proxy server, if the proxy requires authentication.
+
 **Reference Name**: Name used to uniquely identify this source for lineage, annotating metadata, etc.
 
 **Table Name**: The name of the ServiceNow table into which data is to be pushed.

--- a/docs/ServiceNow-batchsource.md
+++ b/docs/ServiceNow-batchsource.md
@@ -27,6 +27,15 @@ You also can use the macro function ${conn(connection-name)}.
 
 **Password**: The password for ServiceNow Instance.
 
+**Proxy URL**: Proxy URL through which all the ServiceNow API calls are routed. For example,
+`http://proxy.example.com:8080`. If no scheme is specified (for example, `proxy.example.com:8080`),
+it defaults to `http`. Specify `https://` explicitly
+when using an HTTPS proxy. Leave it empty to connect to ServiceNow directly.
+
+**Proxy Username**: The username to authenticate with the proxy server, if the proxy requires authentication.
+
+**Proxy Password**: The password to authenticate with the proxy server, if the proxy requires authentication.
+
 **Reference Name**: Name used to uniquely identify this source for lineage, annotating metadata, etc.
 
 **Mode**: Mode of query. The mode can be one of two values: 

--- a/docs/ServiceNow-connector.md
+++ b/docs/ServiceNow-connector.md
@@ -20,6 +20,15 @@ Properties
 
 **Password**: The password for ServiceNow Instance.
 
+**Proxy URL**: Proxy URL through which all the ServiceNow API calls are routed. For example,
+`http://proxy.example.com:8080`. If no scheme is specified (for example, `proxy.example.com:8080`),
+it defaults to `http`. Specify `https://` explicitly
+when using an HTTPS proxy. Leave it empty to connect to ServiceNow directly.
+
+**Proxy Username**: The username to authenticate with the proxy server, if the proxy requires authentication.
+
+**Proxy Password**: The password to authenticate with the proxy server, if the proxy requires authentication.
+
 
 Path of the connection
 ----------------------

--- a/docs/ServiceNowMultiSource-batchsource.md
+++ b/docs/ServiceNowMultiSource-batchsource.md
@@ -22,6 +22,15 @@ Properties
 
 **Password**: The password for ServiceNow Instance.
 
+**Proxy URL**: Proxy URL through which all the ServiceNow API calls are routed. For example,
+`http://proxy.example.com:8080`. If no scheme is specified (for example, `proxy.example.com:8080`),
+it defaults to `http`. Specify `https://` explicitly
+when using an HTTPS proxy. Leave it empty to connect to ServiceNow directly.
+
+**Proxy Username**: The username to authenticate with the proxy server, if the proxy requires authentication.
+
+**Proxy Password**: The password to authenticate with the proxy server, if the proxy requires authentication.
+
 **Reference Name**: Name used to uniquely identify this source for lineage, annotating metadata, etc.
 
 **Table Names**: The name of the ServiceNow table(s) from which data to be fetched.

--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,10 @@
       <scope>provided</scope>
       <exclusions>
         <exclusion>
+          <groupId>commons-codec</groupId>
+          <artifactId>commons-codec</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>

--- a/src/e2e-test/resources/errorMessage.properties
+++ b/src/e2e-test/resources/errorMessage.properties
@@ -5,7 +5,7 @@ validationSuccessMessage=No errors found.
 invalid.property.tablename=ServiceNow API returned an unexpected result or the specified table may not exist. Cause: Http call to ServiceNow instance returned status code 400. Ensure specified table exists in the datasource.
 invalid.property.startdate=Invalid format for Start date. Correct Format: yyyy-MM-dd
 invalid.property.enddate=Invalid format for End date. Correct Format: yyyy-MM-dd
-invalid.property.credentials=Unable to connect to ServiceNow Instance. Ensure properties like Client ID, Client Secret, API Endpoint, User Name, Password are correct.
+invalid.property.credentials=Unable to connect to ServiceNow Instance. Ensure properties like Client ID, Client Secret, API Endpoint, User Name, Password and Proxy Properties are correct.
 
 #Logs error message
 invalid.tablename.logsmessage=ServiceNow API returned an unexpected result or the specified table may not exist.

--- a/src/main/java/io/cdap/plugin/servicenow/ServiceNowBaseConfig.java
+++ b/src/main/java/io/cdap/plugin/servicenow/ServiceNowBaseConfig.java
@@ -89,13 +89,16 @@ public class ServiceNowBaseConfig extends PluginConfig {
       restApi.getAccessToken();
     } catch (Exception e) {
       collector.addFailure("Unable to connect to ServiceNow Instance.",
-                           "Ensure properties like Client ID, Client Secret, API Endpoint, User Name, Password " +
-                             "are correct.")
+                           "Ensure properties like Client ID, Client Secret, API Endpoint, User Name, " +
+                                   "Password and Proxy Properties are correct.")
         .withConfigProperty(ServiceNowConstants.PROPERTY_CLIENT_ID)
         .withConfigProperty(ServiceNowConstants.PROPERTY_CLIENT_SECRET)
         .withConfigProperty(ServiceNowConstants.PROPERTY_API_ENDPOINT)
         .withConfigProperty(ServiceNowConstants.PROPERTY_USER)
         .withConfigProperty(ServiceNowConstants.PROPERTY_PASSWORD)
+        .withConfigProperty(ServiceNowConstants.PROPERTY_PROXY_URL)
+        .withConfigProperty(ServiceNowConstants.PROPERTY_PROXY_USERNAME)
+        .withConfigProperty(ServiceNowConstants.PROPERTY_PROXY_PASSWORD)
         .withStacktrace(e.getStackTrace());
     }
   }
@@ -108,7 +111,10 @@ public class ServiceNowBaseConfig extends PluginConfig {
       !containsMacro(ServiceNowConstants.PROPERTY_CLIENT_SECRET) &&
       !containsMacro(ServiceNowConstants.PROPERTY_API_ENDPOINT) &&
       !containsMacro(ServiceNowConstants.PROPERTY_USER) &&
-      !containsMacro(ServiceNowConstants.PROPERTY_PASSWORD);
+      !containsMacro(ServiceNowConstants.PROPERTY_PASSWORD) &&
+      !containsMacro(ServiceNowConstants.PROPERTY_PROXY_URL)  &&
+      !containsMacro(ServiceNowConstants.PROPERTY_PROXY_USERNAME)  &&
+      !containsMacro(ServiceNowConstants.PROPERTY_PROXY_PASSWORD);
   }
 
   public boolean shouldGetSchema() {

--- a/src/main/java/io/cdap/plugin/servicenow/apiclient/ServiceNowTableAPIClientImpl.java
+++ b/src/main/java/io/cdap/plugin/servicenow/apiclient/ServiceNowTableAPIClientImpl.java
@@ -49,7 +49,6 @@ import org.apache.http.HttpEntity;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
 import org.apache.oltu.oauth2.common.exception.OAuthProblemException;
 import org.apache.oltu.oauth2.common.exception.OAuthSystemException;
 import org.slf4j.Logger;
@@ -86,6 +85,7 @@ public class ServiceNowTableAPIClientImpl extends RestAPIClient {
   public static JsonArray serviceNowJsonResultArray;
 
   public ServiceNowTableAPIClientImpl(ServiceNowConnectorConfig conf, Boolean useConnection) {
+    super(conf.getProxyUrl(), conf.getProxyUsername(), conf.getProxyPassword());
     this.conf = conf;
     this.schemaType = getSchemaTypeBasedOnUseConnection(useConnection);
   }
@@ -561,7 +561,7 @@ public class ServiceNowTableAPIClientImpl extends RestAPIClient {
     deleteRequest.setHeader("Authorization", "Bearer " + accessToken);
     deleteRequest.setHeader("Accept", "application/json");
 
-    try (CloseableHttpClient httpClient = HttpClients.createDefault();
+    try (CloseableHttpClient httpClient = getHttpClientBuilder().build();
          CloseableHttpResponse response = httpClient.execute(deleteRequest)) {
 
       int statusCode = response.getStatusLine().getStatusCode();

--- a/src/main/java/io/cdap/plugin/servicenow/connector/ServiceNowConnectorConfig.java
+++ b/src/main/java/io/cdap/plugin/servicenow/connector/ServiceNowConnectorConfig.java
@@ -23,6 +23,7 @@ import io.cdap.cdap.etl.api.FailureCollector;
 import io.cdap.plugin.servicenow.apiclient.ServiceNowTableAPIClientImpl;
 import io.cdap.plugin.servicenow.util.ServiceNowConstants;
 import io.cdap.plugin.servicenow.util.Util;
+import org.apache.http.HttpHost;
 
 import javax.annotation.Nullable;
 
@@ -62,13 +63,41 @@ public class ServiceNowConnectorConfig extends PluginConfig {
   @Description("The password for ServiceNow Instance.")
   private final String password;
 
+  @Name(ServiceNowConstants.PROPERTY_PROXY_URL)
+  @Macro
+  @Nullable
+  @Description("Proxy URL through which all the ServiceNow API calls are routed. " +
+    "Must contain a protocol, address and port. For example, http://proxy.example.com:8080")
+  private final String proxyUrl;
+
+  @Name(ServiceNowConstants.PROPERTY_PROXY_USERNAME)
+  @Macro
+  @Nullable
+  @Description("The username to authenticate with the proxy server, if the proxy requires authentication.")
+  private final String proxyUsername;
+
+  @Name(ServiceNowConstants.PROPERTY_PROXY_PASSWORD)
+  @Macro
+  @Nullable
+  @Description("The password to authenticate with the proxy server, if the proxy requires authentication.")
+  private final String proxyPassword;
+
   public ServiceNowConnectorConfig(String clientId, String clientSecret, String restApiEndpoint,
                                    String user, String password) {
+    this(clientId, clientSecret, restApiEndpoint, user, password, null, null, null);
+  }
+
+  public ServiceNowConnectorConfig(String clientId, String clientSecret, String restApiEndpoint,
+                                   String user, String password, String proxyUrl, String proxyUsername,
+                                   String proxyPassword) {
     this.clientId = clientId;
     this.clientSecret = clientSecret;
     this.restApiEndpoint = restApiEndpoint;
     this.user = user;
     this.password = password;
+    this.proxyUrl = proxyUrl;
+    this.proxyUsername = proxyUsername;
+    this.proxyPassword = proxyPassword;
   }
 
   public String getClientId() {
@@ -89,6 +118,28 @@ public class ServiceNowConnectorConfig extends PluginConfig {
 
   public String getPassword() {
     return password;
+  }
+
+  @Nullable
+  public String getProxyUrl() {
+    return proxyUrl;
+  }
+
+  @Nullable
+  public String getProxyUsername() {
+    return proxyUsername;
+  }
+
+  @Nullable
+  public String getProxyPassword() {
+    return proxyPassword;
+  }
+
+  /**
+   * Returns true if the proxy properties do not contain macros and a proxy URL has been configured.
+   */
+  public boolean hasProxyConfigured() {
+    return !containsMacro(ServiceNowConstants.PROPERTY_PROXY_URL) && !Util.isNullOrEmpty(proxyUrl);
   }
 
 
@@ -119,6 +170,43 @@ public class ServiceNowConnectorConfig extends PluginConfig {
     if (Util.isNullOrEmpty(getPassword())) {
       collector.addFailure("Password must be specified.", null)
         .withConfigProperty(ServiceNowConstants.PROPERTY_PASSWORD);
+    }
+
+    validateProxyFields(collector);
+  }
+
+  /**
+   * Validates the optional proxy fields. The proxy URL must be a valid host with a protocol and port, and a proxy
+   * username and password must be provided together.
+   */
+  public void validateProxyFields(FailureCollector collector) {
+    if (!containsMacro(ServiceNowConstants.PROPERTY_PROXY_URL) && !Util.isNullOrEmpty(proxyUrl)) {
+      try {
+        HttpHost host = HttpHost.create(proxyUrl);
+        if (host.getPort() == -1) {
+          throw new IllegalArgumentException();
+        }
+      } catch (IllegalArgumentException e) {
+        collector.addFailure("Proxy URL is not valid.",
+                             "Ensure the Proxy URL contains a protocol, address and port. " +
+                               "For example, http://proxy.example.com:8080.")
+          .withConfigProperty(ServiceNowConstants.PROPERTY_PROXY_URL);
+      }
+    }
+
+    if (containsMacro(ServiceNowConstants.PROPERTY_PROXY_USERNAME)
+      || containsMacro(ServiceNowConstants.PROPERTY_PROXY_PASSWORD)) {
+      return;
+    }
+
+    boolean hasUsername = !Util.isNullOrEmpty(proxyUsername);
+    boolean hasPassword = !Util.isNullOrEmpty(proxyPassword);
+    if (hasUsername && !hasPassword) {
+      collector.addFailure("Proxy password must be specified when a proxy username is provided.", null)
+        .withConfigProperty(ServiceNowConstants.PROPERTY_PROXY_PASSWORD);
+    } else if (!hasUsername && hasPassword) {
+      collector.addFailure("Proxy username must be specified when a proxy password is provided.", null)
+        .withConfigProperty(ServiceNowConstants.PROPERTY_PROXY_USERNAME);
     }
   }
 

--- a/src/main/java/io/cdap/plugin/servicenow/restapi/ProxyOltuHttpClient.java
+++ b/src/main/java/io/cdap/plugin/servicenow/restapi/ProxyOltuHttpClient.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright © 2026 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.servicenow.restapi;
+
+import org.apache.http.Header;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.util.EntityUtils;
+import org.apache.oltu.oauth2.client.HttpClient;
+import org.apache.oltu.oauth2.client.request.OAuthClientRequest;
+import org.apache.oltu.oauth2.client.response.OAuthClientResponse;
+import org.apache.oltu.oauth2.client.response.OAuthClientResponseFactory;
+import org.apache.oltu.oauth2.common.OAuth;
+import org.apache.oltu.oauth2.common.exception.OAuthProblemException;
+import org.apache.oltu.oauth2.common.exception.OAuthSystemException;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * An implementation of Oltu's {@link HttpClient} backed by Apache {@link CloseableHttpClient}. It is used so that the
+ * OAuth token request is executed through the same proxy-aware HTTP client as the rest of the ServiceNow API calls.
+ */
+public class ProxyOltuHttpClient implements HttpClient {
+
+  private final HttpClientBuilder httpClientBuilder;
+
+  public ProxyOltuHttpClient(HttpClientBuilder httpClientBuilder) {
+    this.httpClientBuilder = httpClientBuilder;
+  }
+
+  @Override
+  public <T extends OAuthClientResponse> T execute(OAuthClientRequest request, Map<String, String> headers,
+                                                   String requestMethod, Class<T> responseClass)
+    throws OAuthSystemException, OAuthProblemException {
+
+    HttpRequestBase httpRequest;
+    if (OAuth.HttpMethod.POST.equalsIgnoreCase(requestMethod) || OAuth.HttpMethod.PUT.equalsIgnoreCase(requestMethod)) {
+      HttpPost httpPost = new HttpPost(request.getLocationUri());
+      if (request.getBody() != null) {
+        httpPost.setEntity(new StringEntity(request.getBody(), StandardCharsets.UTF_8));
+      }
+      httpRequest = httpPost;
+    } else {
+      httpRequest = new HttpGet(request.getLocationUri());
+    }
+
+    if (request.getHeaders() != null) {
+      request.getHeaders().forEach(httpRequest::setHeader);
+    }
+    if (headers != null) {
+      headers.forEach(httpRequest::setHeader);
+    }
+    if (httpRequest.getFirstHeader(OAuth.HeaderType.CONTENT_TYPE) == null) {
+      httpRequest.setHeader(OAuth.HeaderType.CONTENT_TYPE, OAuth.ContentType.URL_ENCODED);
+    }
+
+    try (CloseableHttpClient httpClient = httpClientBuilder.build();
+         CloseableHttpResponse response = httpClient.execute(httpRequest)) {
+      int responseCode = response.getStatusLine().getStatusCode();
+      String contentType = response.getEntity() != null && response.getEntity().getContentType() != null
+        ? response.getEntity().getContentType().getValue() : null;
+      String body = response.getEntity() != null ? EntityUtils.toString(response.getEntity()) : "";
+      return OAuthClientResponseFactory.createCustomResponse(body, contentType, responseCode,
+                                                             extractHeaders(response), responseClass);
+    } catch (IOException e) {
+      throw new OAuthSystemException(e);
+    }
+  }
+
+  @Override
+  public void shutdown() {
+    // No persistent resources are held; a fresh client is created per request and closed in execute().
+  }
+
+  private Map<String, List<String>> extractHeaders(CloseableHttpResponse response) {
+    Map<String, List<String>> responseHeaders = new java.util.HashMap<>();
+    for (Header header : response.getAllHeaders()) {
+      List<String> values = responseHeaders.computeIfAbsent(header.getName(), k -> new ArrayList<>());
+      values.add(header.getValue());
+    }
+    return Collections.unmodifiableMap(responseHeaders);
+  }
+}

--- a/src/main/java/io/cdap/plugin/servicenow/restapi/RestAPIClient.java
+++ b/src/main/java/io/cdap/plugin/servicenow/restapi/RestAPIClient.java
@@ -22,13 +22,19 @@ import com.github.rholder.retry.Retryer;
 import com.github.rholder.retry.RetryerBuilder;
 import com.github.rholder.retry.StopStrategies;
 import com.github.rholder.retry.WaitStrategies;
+import com.google.common.base.Strings;
 import io.cdap.plugin.servicenow.apiclient.ServiceNowAPIException;
 import io.cdap.plugin.servicenow.util.ServiceNowConstants;
+import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.conn.ConnectTimeoutException;
+import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.oltu.oauth2.client.OAuthClient;
@@ -48,13 +54,14 @@ import java.util.Collections;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
 
 /**
  * An abstract class to call Rest API.
  */
 public abstract class RestAPIClient {
   private static final Logger LOG = LoggerFactory.getLogger(RestAPIClient.class);
-  
+
   /* Connect Timout in ms for establishing the conenction with the server */
   private static final int DEFAULT_CONNECT_TIMEOUT_MS = 120000;
 
@@ -66,6 +73,43 @@ public abstract class RestAPIClient {
     .setSocketTimeout(DEFAULT_READ_TIMEOUT_MS)
     .build();
 
+  /* Optional proxy through which all the API calls are routed. */
+  private final String proxyUrl;
+  private final String proxyUsername;
+  private final String proxyPassword;
+
+  protected RestAPIClient() {
+    this(null, null, null);
+  }
+
+  protected RestAPIClient(@Nullable String proxyUrl, @Nullable String proxyUsername, @Nullable String proxyPassword) {
+    this.proxyUrl = proxyUrl;
+    this.proxyUsername = proxyUsername;
+    this.proxyPassword = proxyPassword;
+  }
+
+  /**
+   * Builds an {@link HttpClientBuilder} pre-configured with the default request timeouts and, when a proxy is
+   * configured, the proxy host along with its credentials. All ServiceNow API calls go through the resulting client
+   * so that, if a proxy is set, traffic is routed to the proxy first and then to the ServiceNow instance.
+   *
+   * @return an HttpClientBuilder configured with timeouts and optional proxy settings.
+   */
+  protected HttpClientBuilder getHttpClientBuilder() {
+    HttpClientBuilder httpClientBuilder = HttpClientBuilder.create().setDefaultRequestConfig(requestConfig);
+    if (!Strings.isNullOrEmpty(proxyUrl)) {
+      HttpHost proxyHost = HttpHost.create(proxyUrl);
+      if (!Strings.isNullOrEmpty(proxyUsername) && !Strings.isNullOrEmpty(proxyPassword)) {
+        CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+        credentialsProvider.setCredentials(new AuthScope(proxyHost),
+                                           new UsernamePasswordCredentials(proxyUsername, proxyPassword));
+        httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider);
+      }
+      httpClientBuilder.setProxy(proxyHost);
+    }
+    return httpClientBuilder;
+  }
+
   /**
    * Executes the Rest API request and returns the response.
    *
@@ -76,7 +120,7 @@ public abstract class RestAPIClient {
     HttpGet httpGet = new HttpGet(request.getUrl());
     request.getHeaders().entrySet().forEach(e -> httpGet.addHeader(e.getKey(), e.getValue()));
 
-    try (CloseableHttpClient httpClient = HttpClientBuilder.create().setDefaultRequestConfig(requestConfig).build()) {
+    try (CloseableHttpClient httpClient = getHttpClientBuilder().build()) {
       try (CloseableHttpResponse httpResponse = httpClient.execute(httpGet)) {
         return RestAPIResponse.parse(httpResponse, request.getResponseHeaders());
       }
@@ -154,7 +198,7 @@ public abstract class RestAPIClient {
     // We're retrying all transport exceptions while executing the HTTP POST method and the generic transport
     // exceptions in HttpClient are represented by the standard java.io.IOException class
     // https://hc.apache.org/httpclient-legacy/exception-handling.html
-    try (CloseableHttpClient httpClient = HttpClientBuilder.create().setDefaultRequestConfig(requestConfig).build()) {
+    try (CloseableHttpClient httpClient = getHttpClientBuilder().build()) {
       try (CloseableHttpResponse httpResponse = httpClient.execute(httpPost)) {
         return RestAPIResponse.parse(httpResponse, request.getResponseHeaders());
       }
@@ -176,7 +220,11 @@ public abstract class RestAPIClient {
                                        String password) throws OAuthSystemException, OAuthProblemException {
     String token = "NO-VALUE";
 
-    OAuthClient client = new OAuthClient(new URLConnectionClient());
+    // When a proxy is configured, route the OAuth token request through the same proxy-aware HTTP client as the rest
+    // of the ServiceNow API calls. Otherwise, keep using the default URLConnectionClient for backward compatibility.
+    org.apache.oltu.oauth2.client.HttpClient oltuHttpClient = Strings.isNullOrEmpty(proxyUrl)
+      ? new URLConnectionClient() : new ProxyOltuHttpClient(getHttpClientBuilder());
+    OAuthClient client = new OAuthClient(oltuHttpClient);
     OAuthClientRequest request = OAuthClientRequest.tokenLocation(restApiEndpoint)
       .setGrantType(GrantType.PASSWORD)
       .setClientId(clientId)

--- a/src/main/java/io/cdap/plugin/servicenow/util/ServiceNowConstants.java
+++ b/src/main/java/io/cdap/plugin/servicenow/util/ServiceNowConstants.java
@@ -87,6 +87,21 @@ public interface ServiceNowConstants {
   String PROPERTY_PASSWORD = "password";
 
   /**
+   * Configuration property name used to specify the proxy URL. Must contain a protocol, address and port.
+   */
+  String PROPERTY_PROXY_URL = "proxyUrl";
+
+  /**
+   * Configuration property name used to specify the proxy username.
+   */
+  String PROPERTY_PROXY_USERNAME = "proxyUsername";
+
+  /**
+   * Configuration property name used to specify the proxy password.
+   */
+  String PROPERTY_PROXY_PASSWORD = "proxyPassword";
+
+  /**
    * Configuration property name used to specify the type of operation.
    */
   String PROPERTY_OPERATION = "operation";

--- a/src/test/java/io/cdap/plugin/servicenow/connector/ServiceNowConnectorConfigProxyTest.java
+++ b/src/test/java/io/cdap/plugin/servicenow/connector/ServiceNowConnectorConfigProxyTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright © 2026 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.servicenow.connector;
+
+import io.cdap.cdap.etl.api.validation.CauseAttributes;
+import io.cdap.cdap.etl.api.validation.ValidationFailure;
+import io.cdap.cdap.etl.mock.validation.MockFailureCollector;
+import io.cdap.plugin.servicenow.util.ServiceNowConstants;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+
+/**
+ * Tests for the proxy configuration on {@link ServiceNowConnectorConfig}.
+ */
+public class ServiceNowConnectorConfigProxyTest {
+
+  private static ServiceNowConnectorConfig configWithProxy(String proxyUrl, String proxyUsername,
+                                                           String proxyPassword) {
+    return new ServiceNowConnectorConfig("clientId", "clientSecret", "https://instance.service-now.com",
+                                         "user", "password", proxyUrl, proxyUsername, proxyPassword);
+  }
+
+  @Test
+  public void testProxyGettersAndDetection() {
+    ServiceNowConnectorConfig config = configWithProxy("http://proxy.example.com:8080", "puser", "ppass");
+    Assert.assertEquals("http://proxy.example.com:8080", config.getProxyUrl());
+    Assert.assertEquals("puser", config.getProxyUsername());
+    Assert.assertEquals("ppass", config.getProxyPassword());
+    Assert.assertTrue(config.hasProxyConfigured());
+  }
+
+  @Test
+  public void testNoProxyConfigured() {
+    ServiceNowConnectorConfig config = configWithProxy(null, null, null);
+    Assert.assertFalse(config.hasProxyConfigured());
+    MockFailureCollector collector = new MockFailureCollector();
+    config.validateProxyFields(collector);
+    Assert.assertEquals(0, collector.getValidationFailures().size());
+  }
+
+  @Test
+  public void testValidProxyPassesValidation() {
+    ServiceNowConnectorConfig config = configWithProxy("http://proxy.example.com:8080", "puser", "ppass");
+    MockFailureCollector collector = new MockFailureCollector();
+    config.validateProxyFields(collector);
+    Assert.assertEquals(0, collector.getValidationFailures().size());
+  }
+
+  @Test
+  public void testInvalidProxyUrlFailsValidation() {
+    ServiceNowConnectorConfig config = configWithProxy("not a valid url", null, null);
+    MockFailureCollector collector = new MockFailureCollector();
+    config.validateProxyFields(collector);
+    List<ValidationFailure> failures = collector.getValidationFailures();
+    Assert.assertEquals(1, failures.size());
+    Assert.assertEquals(ServiceNowConstants.PROPERTY_PROXY_URL,
+                        failures.get(0).getCauses().get(0).getAttribute(CauseAttributes.STAGE_CONFIG));
+  }
+
+  @Test
+  public void testProxyUsernameWithoutPasswordFailsValidation() {
+    ServiceNowConnectorConfig config = configWithProxy("http://proxy.example.com:8080", "puser", null);
+    MockFailureCollector collector = new MockFailureCollector();
+    config.validateProxyFields(collector);
+    List<ValidationFailure> failures = collector.getValidationFailures();
+    Assert.assertEquals(1, failures.size());
+    Assert.assertEquals(ServiceNowConstants.PROPERTY_PROXY_PASSWORD,
+                        failures.get(0).getCauses().get(0).getAttribute(CauseAttributes.STAGE_CONFIG));
+  }
+
+  @Test
+  public void testProxyPasswordWithoutUsernameFailsValidation() {
+    ServiceNowConnectorConfig config = configWithProxy("http://proxy.example.com:8080", null, "ppass");
+    MockFailureCollector collector = new MockFailureCollector();
+    config.validateProxyFields(collector);
+    List<ValidationFailure> failures = collector.getValidationFailures();
+    Assert.assertEquals(1, failures.size());
+    Assert.assertEquals(ServiceNowConstants.PROPERTY_PROXY_USERNAME,
+                        failures.get(0).getCauses().get(0).getAttribute(CauseAttributes.STAGE_CONFIG));
+  }
+}

--- a/src/test/java/io/cdap/plugin/servicenow/restapi/ProxyOltuHttpClientTest.java
+++ b/src/test/java/io/cdap/plugin/servicenow/restapi/ProxyOltuHttpClientTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright © 2026 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.servicenow.restapi;
+
+import org.apache.http.Header;
+import org.apache.http.ProtocolVersion;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.message.BasicStatusLine;
+import org.apache.oltu.oauth2.client.request.OAuthClientRequest;
+import org.apache.oltu.oauth2.client.response.OAuthJSONAccessTokenResponse;
+import org.apache.oltu.oauth2.common.OAuth;
+import org.apache.oltu.oauth2.common.exception.OAuthSystemException;
+import org.apache.oltu.oauth2.common.message.types.GrantType;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+
+/**
+ * Tests for {@link ProxyOltuHttpClient}.
+ */
+public class ProxyOltuHttpClientTest {
+
+  private static final String TOKEN_URL = "https://instance.service-now.com/oauth_token.do";
+
+  private static OAuthClientRequest tokenRequest() throws OAuthSystemException {
+    return OAuthClientRequest.tokenLocation(TOKEN_URL)
+      .setGrantType(GrantType.PASSWORD)
+      .setClientId("clientId")
+      .setClientSecret("clientSecret")
+      .setUsername("user")
+      .setPassword("password")
+      .buildBodyMessage();
+  }
+
+  private static CloseableHttpResponse mockResponse(int statusCode, String body) throws IOException {
+    CloseableHttpResponse response = Mockito.mock(CloseableHttpResponse.class);
+    Mockito.when(response.getStatusLine())
+      .thenReturn(new BasicStatusLine(new ProtocolVersion("HTTP", 1, 1), statusCode, "OK"));
+    Mockito.when(response.getEntity()).thenReturn(new StringEntity(body, ContentType.APPLICATION_JSON));
+    Mockito.when(response.getAllHeaders()).thenReturn(new Header[0]);
+    return response;
+  }
+
+  private static HttpClientBuilder mockBuilderReturning(CloseableHttpClient httpClient) {
+    HttpClientBuilder builder = Mockito.mock(HttpClientBuilder.class);
+    Mockito.when(builder.build()).thenReturn(httpClient);
+    return builder;
+  }
+
+  @Test
+  public void testExecutePostParsesTokenAndUsesPost() throws Exception {
+    CloseableHttpClient httpClient = Mockito.mock(CloseableHttpClient.class);
+    CloseableHttpResponse response = mockResponse(200, "{\"access_token\":\"tok\",\"token_type\":\"Bearer\"}");
+    ArgumentCaptor<HttpUriRequest> captor = ArgumentCaptor.forClass(HttpUriRequest.class);
+    Mockito.when(httpClient.execute(captor.capture())).thenReturn(response);
+
+    ProxyOltuHttpClient client = new ProxyOltuHttpClient(mockBuilderReturning(httpClient));
+    OAuthJSONAccessTokenResponse tokenResponse =
+      client.execute(tokenRequest(), null, OAuth.HttpMethod.POST, OAuthJSONAccessTokenResponse.class);
+
+    Assert.assertEquals("tok", tokenResponse.getAccessToken());
+
+    HttpUriRequest executed = captor.getValue();
+    Assert.assertTrue(executed instanceof HttpPost);
+    Assert.assertEquals(TOKEN_URL, executed.getURI().toString());
+    // The token request is form-encoded, so a Content-Type header must be present.
+    Assert.assertNotNull(executed.getFirstHeader(OAuth.HeaderType.CONTENT_TYPE));
+  }
+
+  @Test
+  public void testExecuteGetUsesGet() throws Exception {
+    CloseableHttpClient httpClient = Mockito.mock(CloseableHttpClient.class);
+    CloseableHttpResponse response = mockResponse(200, "{\"access_token\":\"tok\"}");
+    ArgumentCaptor<HttpUriRequest> captor = ArgumentCaptor.forClass(HttpUriRequest.class);
+    Mockito.when(httpClient.execute(captor.capture())).thenReturn(response);
+
+    ProxyOltuHttpClient client = new ProxyOltuHttpClient(mockBuilderReturning(httpClient));
+    client.execute(tokenRequest(), null, OAuth.HttpMethod.GET, OAuthJSONAccessTokenResponse.class);
+
+    Assert.assertTrue(captor.getValue() instanceof HttpGet);
+  }
+
+  @Test(expected = OAuthSystemException.class)
+  public void testIOExceptionIsWrapped() throws Exception {
+    CloseableHttpClient httpClient = Mockito.mock(CloseableHttpClient.class);
+    Mockito.when(httpClient.execute(Mockito.any(HttpUriRequest.class))).thenThrow(new IOException("boom"));
+
+    ProxyOltuHttpClient client = new ProxyOltuHttpClient(mockBuilderReturning(httpClient));
+    client.execute(tokenRequest(), null, OAuth.HttpMethod.POST, OAuthJSONAccessTokenResponse.class);
+  }
+}

--- a/src/test/java/io/cdap/plugin/servicenow/restapi/RestAPIClientProxyTest.java
+++ b/src/test/java/io/cdap/plugin/servicenow/restapi/RestAPIClientProxyTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright © 2026 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.servicenow.restapi;
+
+import org.apache.http.HttpHost;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+
+/**
+ * Tests for the proxy wiring in {@link RestAPIClient#getHttpClientBuilder()}.
+ *
+ * <p>{@link HttpClientBuilder#setProxy(HttpHost)} and related setters are {@code final}, so they cannot be mocked.
+ * Instead these tests build a real {@link HttpClientBuilder} and inspect its private {@code proxy} and
+ * {@code credentialsProvider} fields to assert that the proxy was wired in.</p>
+ */
+public class RestAPIClientProxyTest {
+
+  /**
+   * Minimal concrete subclass to exercise the abstract {@link RestAPIClient}.
+   */
+  private static final class TestRestAPIClient extends RestAPIClient {
+    private TestRestAPIClient(String proxyUrl, String proxyUsername, String proxyPassword) {
+      super(proxyUrl, proxyUsername, proxyPassword);
+    }
+  }
+
+  private static Object readField(HttpClientBuilder builder, String fieldName) throws Exception {
+    Field field = HttpClientBuilder.class.getDeclaredField(fieldName);
+    field.setAccessible(true);
+    return field.get(builder);
+  }
+
+  @Test
+  public void testProxyWithCredentialsSetsProxyAndCredentials() throws Exception {
+    HttpClientBuilder builder =
+      new TestRestAPIClient("http://proxy.example.com:8080", "puser", "ppass").getHttpClientBuilder();
+
+    HttpHost proxy = (HttpHost) readField(builder, "proxy");
+    Assert.assertNotNull(proxy);
+    Assert.assertEquals("proxy.example.com", proxy.getHostName());
+    Assert.assertEquals(8080, proxy.getPort());
+    Assert.assertNotNull(readField(builder, "credentialsProvider"));
+  }
+
+  @Test
+  public void testProxyWithoutCredentialsSetsProxyOnly() throws Exception {
+    HttpClientBuilder builder =
+      new TestRestAPIClient("http://proxy.example.com:8080", null, null).getHttpClientBuilder();
+
+    Assert.assertNotNull(readField(builder, "proxy"));
+    Assert.assertNull(readField(builder, "credentialsProvider"));
+    // The builder should still produce a usable client.
+    Assert.assertNotNull(builder.build());
+  }
+
+  @Test
+  public void testNoProxyDoesNotSetProxy() throws Exception {
+    HttpClientBuilder builder = new TestRestAPIClient(null, null, null).getHttpClientBuilder();
+
+    Assert.assertNull(readField(builder, "proxy"));
+    Assert.assertNull(readField(builder, "credentialsProvider"));
+    Assert.assertNotNull(builder.build());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testInvalidProxyUrlThrows() {
+    new TestRestAPIClient("not a valid url", null, null).getHttpClientBuilder();
+  }
+}

--- a/widgets/ServiceNow-batchsink.json
+++ b/widgets/ServiceNow-batchsink.json
@@ -70,6 +70,24 @@
           "widget-attributes": {
             "placeholder": "ServiceNow User Password"
           }
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Proxy URL",
+          "name": "proxyUrl",
+          "widget-attributes": {
+            "placeholder": "Proxy URL e.g. http://proxy.example.com:8080"
+          }
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Proxy Username",
+          "name": "proxyUsername"
+        },
+        {
+          "widget-type": "password",
+          "label": "Proxy Password",
+          "name": "proxyPassword"
         }
       ]
     },
@@ -180,8 +198,11 @@
         {
           "type": "property",
           "name": "password"
+        },
+        {
+          "type": "property",
+          "name": "proxyUrl"
         }
-
       ]
     },
     {
@@ -193,6 +214,23 @@
         {
           "type": "property",
           "name": "connection"
+        }
+      ]
+    },
+    {
+      "name": "Proxy authentication",
+      "condition": {
+        "property": "proxyUrl",
+        "operator": "exists"
+      },
+      "show": [
+        {
+          "type": "property",
+          "name": "proxyUsername"
+        },
+        {
+          "type": "property",
+          "name": "proxyPassword"
         }
       ]
     }

--- a/widgets/ServiceNow-batchsource.json
+++ b/widgets/ServiceNow-batchsource.json
@@ -70,6 +70,24 @@
           "widget-attributes": {
             "placeholder": "ServiceNow User Password"
           }
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Proxy URL",
+          "name": "proxyUrl",
+          "widget-attributes": {
+            "placeholder": "Proxy URL e.g. http://proxy.example.com:8080"
+          }
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Proxy Username",
+          "name": "proxyUsername"
+        },
+        {
+          "widget-type": "password",
+          "label": "Proxy Password",
+          "name": "proxyPassword"
         }
       ]
     },
@@ -272,6 +290,10 @@
         {
           "type": "property",
           "name": "password"
+        },
+        {
+          "type": "property",
+          "name": "proxyUrl"
         }
 
       ]
@@ -285,6 +307,23 @@
         {
           "type": "property",
           "name": "connection"
+        }
+      ]
+    },
+    {
+      "name": "Proxy authentication",
+      "condition": {
+        "property": "proxyUrl",
+        "operator": "exists"
+      },
+      "show": [
+        {
+          "type": "property",
+          "name": "proxyUsername"
+        },
+        {
+          "type": "property",
+          "name": "proxyPassword"
         }
       ]
     }

--- a/widgets/ServiceNow-connector.json
+++ b/widgets/ServiceNow-connector.json
@@ -48,7 +48,49 @@
           }
         }
       ]
+    },
+    {
+      "label": "Proxy",
+      "properties": [
+        {
+          "widget-type": "textbox",
+          "label": "Proxy URL",
+          "name": "proxyUrl",
+          "widget-attributes" : {
+            "placeholder": "Proxy URL e.g. http://proxy.example.com:8080"
+          }
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Proxy Username",
+          "name": "proxyUsername"
+        },
+        {
+          "widget-type": "password",
+          "label": "Proxy Password",
+          "name": "proxyPassword"
+        }
+      ]
     }
     ],
-  "outputs": []
+  "outputs": [],
+  "filters": [
+    {
+      "name": "Proxy authentication",
+      "condition": {
+        "property": "proxyUrl",
+        "operator": "exists"
+      },
+      "show": [
+        {
+          "name": "proxyUsername",
+          "type": "property"
+        },
+        {
+          "name": "proxyPassword",
+          "type": "property"
+        }
+      ]
+    }
+  ]
 }

--- a/widgets/ServiceNowMultiSource-batchsource.json
+++ b/widgets/ServiceNowMultiSource-batchsource.json
@@ -70,6 +70,24 @@
           "widget-attributes": {
             "placeholder": "ServiceNow User Password"
           }
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Proxy URL",
+          "name": "proxyUrl",
+          "widget-attributes": {
+            "placeholder": "Proxy URL e.g. http://proxy.example.com:8080"
+          }
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Proxy Username",
+          "name": "proxyUsername"
+        },
+        {
+          "widget-type": "password",
+          "label": "Proxy Password",
+          "name": "proxyPassword"
         }
       ]
     },
@@ -202,6 +220,10 @@
         {
           "type": "property",
           "name": "password"
+        },
+        {
+          "type": "property",
+          "name": "proxyUrl"
         }
 
       ]
@@ -215,6 +237,23 @@
         {
           "type": "property",
           "name": "connection"
+        }
+      ]
+    },
+    {
+      "name": "Proxy authentication",
+      "condition": {
+        "property": "proxyUrl",
+        "operator": "exists"
+      },
+      "show": [
+        {
+          "type": "property",
+          "name": "proxyUsername"
+        },
+        {
+          "type": "property",
+          "name": "proxyPassword"
         }
       ]
     }


### PR DESCRIPTION
Route all ServiceNow API calls (table reads, schema fetch, batch sink writes, OAuth token requests) through an optional HTTP proxy, modeled on the http-plugins proxy support.

- Add proxyUrl, proxyUsername, proxyPassword properties to ServiceNowConnectorConfig (nullable, macro-enabled) with validation
- Build a proxy-aware Apache HttpClient in RestAPIClient used by all GET/POST/DELETE calls
- Route the OAuth token call through the proxy via a new ProxyOltuHttpClient (Oltu HttpClient backed by Apache HttpClient); falls back to URLConnectionClient when no proxy is configured
- Add Proxy fields and a "Proxy authentication" filter to the connector, source, multi-source and sink widgets
- Document the new properties and add unit tests for proxy config

- ProxyOltuHttpClientTest: covers the OAuth-over-proxy client (POST token parsing, GET path, IOException wrapped as OAuthSystemException)
- RestAPIClientProxyTest: covers getHttpClientBuilder() proxy wiring (proxy host + credentials, proxy-only, no-proxy, invalid URL) by inspecting the real HttpClientBuilder's fields, since its setters are final.

Failed e2e are actully getting successful https://storage.googleapis.com/e2e-tests-cucumber-reports/servicenow-plugins/refs/pull/151/merge/cucumber-reports/advanced-reports/cucumber-html-reports/report-feature_8_566810399.html

And one e2e failure is due to slow response from service now instance and canCommit error is coming intermittently.
